### PR TITLE
Create new Message types for slack messages

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,15 @@
+SlackBot = require './src/slack'
+{SlackTextMessage, SlackRawMessage, SlackBotMessage} = require './src/message'
+{SlackRawListener, SlackBotListener} = require './src/listener'
+
+module.exports = exports = {
+  SlackBot
+  SlackTextMessage
+  SlackRawMessage
+  SlackBotMessage
+  SlackRawListener
+  SlackBotListener
+}
+
+exports.use = (robot) ->
+  new SlackBot robot

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "grunt-shell": "~0.5.0",
     "hubot": "~2.10"
   },
-  "main": "./src/slack",
+  "main": "./index",
   "engines": {
     "node": ">=0.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mocha": "~1.13.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-shell": "~0.5.0",
-    "hubot": "~2.10"
+    "hubot": "~2.11"
   },
   "main": "./index",
   "engines": {

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -9,6 +9,10 @@ class SlackRawListener extends Listener
   # matcher  - A Function that determines if this listener should trigger the
   #            callback. The matcher takes a SlackRawMessage.
   # callback - A Function that is triggered if the incoming message matches.
+  #
+  # To use this listener in your own script, you can say
+  #
+  #     robot.listeners.push new SlackRawListener(robot, matcher, callback)
   constructor: (@robot, @matcher, @callback) ->
 
   # Public: Invokes super only for instances of SlackRawMessage
@@ -27,6 +31,10 @@ class SlackBotListener extends Listener
   # regex    - A Regex that determines if this listener should trigger the
   #            callback.
   # callback - A Function that is triggered if the incoming message matches.
+  #
+  # To use this listener in your own script, you can say
+  #
+  #     robot.listeners.push new SlackBotListener(robot, regex, callback)
   constructor: (@robot, @regex, @callback) ->
     @matcher = (message) =>
       if message instanceof SlackBotMessage

--- a/src/listener.coffee
+++ b/src/listener.coffee
@@ -1,0 +1,38 @@
+{Listener} = require 'hubot'
+{SlackRawMessage, SlackBotMessage} = require './message'
+
+class SlackRawListener extends Listener
+  # SlackRawListeners receive SlackRawMessages from the Slack adapter
+  # and decide if they want to act on it.
+  #
+  # robot    - A Robot instance.
+  # matcher  - A Function that determines if this listener should trigger the
+  #            callback. The matcher takes a SlackRawMessage.
+  # callback - A Function that is triggered if the incoming message matches.
+  constructor: (@robot, @matcher, @callback) ->
+
+  # Public: Invokes super only for instances of SlackRawMessage
+  call: (message) ->
+    if message instanceof SlackRawMessage
+      super message
+    else
+      false
+
+class SlackBotListener extends Listener
+  # SlackBotListeners receive SlackBotMessages from the Slack adapter
+  # and decide if they want to act on it. SlackBotListener will only
+  # match instances of SlackBotMessage.
+  #
+  # robot    - A Robot instance.
+  # regex    - A Regex that determines if this listener should trigger the
+  #            callback.
+  # callback - A Function that is triggered if the incoming message matches.
+  constructor: (@robot, @regex, @callback) ->
+    @matcher = (message) =>
+      if message instanceof SlackBotMessage
+        message.match @regex
+
+module.exports = {
+  SlackRawListener
+  SlackBotListener
+}

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -1,0 +1,57 @@
+{TextMessage} = require 'hubot'
+
+class SlackTextMessage extends TextMessage
+  # Represents a TextMessage created from the Slack adapter
+  #
+  # text - The parsed message text
+  # rawText - The unparsed message text
+  constructor: (@user, @text, @rawText, @id) ->
+    super @user, @text, @id
+
+# For some reason Hubot doesn't export Message, but that's what we want to extend.
+# As a workaround, let's grab TextMessage's superclass
+Message = TextMessage.__super__.constructor
+class SlackRawMessage extends Message
+  # Represents Slack messages that are not suitable to treat as text messages.
+  # These are hidden messages, or messages that have no text / attachments.
+  # All properties of the message are exposed from SlackRawMessage, except
+  # as follows:
+  # - user: This property corresponds to Message.user and is nominally a
+  #         Hubot user. However, as many events don't actually have a user
+  #         attached to them, this may be a "fake" user.
+  # - text: If present, this is the parsed text. See `rawText`.
+  # - rawText: If `text` is present, `rawText` contains the unparsed text.
+  constructor: (user, @text, msg) ->
+    for k of (msg or {})
+      if k[0] == "_"
+        # ignore properties starting with _
+      else if k is 'text'
+        @rawText = msg[k]
+      else
+        @[k] = msg[k]
+    super user
+
+class SlackBotMessage extends SlackRawMessage
+  # Represents a message sent by a bot. Specifically, this is any message
+  # with the subtype "bot_message". Expect the `user` property to be a
+  # "fake" user.
+
+  # Determines if the message matches the given regex.
+  #
+  # regex - A Regex to check.
+  #
+  # Returns a Match object or null.
+  match: (regex) ->
+    @text.match regex
+
+  # String representation of a SlackBotMessage
+  #
+  # Returns the message text
+  toString: () ->
+    @text
+
+module.exports = {
+  SlackTextMessage
+  SlackRawMessage
+  SlackBotMessage
+}

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -3,10 +3,12 @@
 class SlackTextMessage extends TextMessage
   # Represents a TextMessage created from the Slack adapter
   #
-  # text - The parsed message text
-  # rawText - The unparsed message text
-  constructor: (@user, @text, @rawText, @id) ->
-    super @user, @text, @id
+  # user       - The User object
+  # text       - The parsed message text
+  # rawText    - The unparsed message text
+  # rawMessage - The Slack Message object
+  constructor: (@user, @text, @rawText, @rawMessage) ->
+    super @user, @text, @rawMessage.ts
 
 # For some reason Hubot doesn't export Message, but that's what we want to extend.
 # As a workaround, let's grab TextMessage's superclass
@@ -14,20 +16,16 @@ Message = TextMessage.__super__.constructor
 class SlackRawMessage extends Message
   # Represents Slack messages that are not suitable to treat as text messages.
   # These are hidden messages, or messages that have no text / attachments.
-  # All properties of the message are exposed from SlackRawMessage, except
-  # as follows:
-  # - user: This property corresponds to Message.user and is nominally a
-  #         Hubot user. However, as many events don't actually have a user
-  #         attached to them, this may be a "fake" user.
-  # - text: If present, this is the parsed text. See `rawText`.
-  # - rawText: If `text` is present, `rawText` contains the unparsed text.
-  constructor: (user, @text, msg) ->
-    for own k, v of (msg or {})
-      switch
-        when k[0] is '_' then # ignore properties starting with _
-        when k is 'text' then @rawText = v
-        else @[k] = v
-    super user
+  #
+  # Note that the `user` property may be a "fake" user, i.e. one that does not
+  # exist in Hubot's brain and that contains little to no data.
+  #
+  # user       - The User object
+  # text       - The parsed message text, if any, or ""
+  # rawText    - The unparsed message text, if any, or ""
+  # rawMessage - The Slack Message object
+  constructor: (@user, @text = "", @rawText = "", @rawMessage) ->
+    super @user
 
 class SlackBotMessage extends SlackRawMessage
   # Represents a message sent by a bot. Specifically, this is any message

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -22,13 +22,11 @@ class SlackRawMessage extends Message
   # - text: If present, this is the parsed text. See `rawText`.
   # - rawText: If `text` is present, `rawText` contains the unparsed text.
   constructor: (user, @text, msg) ->
-    for k of (msg or {})
-      if k[0] == "_"
-        # ignore properties starting with _
-      else if k is 'text'
-        @rawText = msg[k]
-      else
-        @[k] = msg[k]
+    for own k, v of (msg or {})
+      switch
+        when k[0] is '_' then # ignore properties starting with _
+        when k is 'text' then @rawText = v
+        else @[k] = v
     super user
 
 class SlackBotMessage extends SlackRawMessage

--- a/src/message.coffee
+++ b/src/message.coffee
@@ -1,4 +1,10 @@
-{TextMessage} = require 'hubot'
+{Message, TextMessage} = require 'hubot'
+
+# Hubot only started exporting Message in 2.11.0. Previous version do not export
+# this class. In order to remain compatible with older versions, we can pull the
+# Message class from TextMessage superclass.
+if not Message
+  Message = TextMessage.__super__.constructor
 
 class SlackTextMessage extends TextMessage
   # Represents a TextMessage created from the Slack adapter
@@ -10,9 +16,6 @@ class SlackTextMessage extends TextMessage
   constructor: (@user, @text, @rawText, @rawMessage) ->
     super @user, @text, @rawMessage.ts
 
-# For some reason Hubot doesn't export Message, but that's what we want to extend.
-# As a workaround, let's grab TextMessage's superclass
-Message = TextMessage.__super__.constructor
 class SlackRawMessage extends Message
   # Represents Slack messages that are not suitable to treat as text messages.
   # These are hidden messages, or messages that have no text / attachments.

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -108,15 +108,15 @@ class SlackBot extends Adapter
         user.name = msg.username if msg.username?
       user.room = channel.name if channel
 
-      if msg.text? or msg.attachments
-        text = @removeFormatting msg.getBody()
+      rawText = msg.getBody()
+      text = @removeFormatting rawText
 
       if msg.subtype is 'bot_message'
         @robot.logger.debug "Received bot message: '#{text}' in channel: #{channel?.name}, from: #{user?.name}"
-        @receive new SlackBotMessage user, text, msg
+        @receive new SlackBotMessage user, text, rawText, msg
       else
         @robot.logger.debug "Received raw message (subtype: #{msg.subtype})"
-        @receive new SlackRawMessage user, text, msg
+        @receive new SlackRawMessage user, text, rawText, msg
       return
 
     # Process the user into a full hubot user
@@ -147,7 +147,7 @@ class SlackBot extends Adapter
       if msg.getChannelType() == 'DM'
         text = "#{@robot.name} #{text}"
 
-      @receive new SlackTextMessage user, text, rawText, msg.ts
+      @receive new SlackTextMessage user, text, rawText, msg
 
   removeFormatting: (text) ->
     # https://api.slack.com/docs/formatting

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -1,4 +1,6 @@
-{Robot, Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage} = require 'hubot'
+{Robot, Adapter, EnterMessage, LeaveMessage, TopicMessage} = require 'hubot'
+{SlackTextMessage, SlackRawMessage, SlackBotMessage} = require './message'
+{SlackRawListener, SlackBotListener} = require './listener'
 
 SlackClient = require 'slack-client'
 Util = require 'util'
@@ -89,19 +91,33 @@ class SlackBot extends Adapter
     process.exit 0
 
   message: (msg) =>
-    return if msg.hidden
-    return if not msg.text and not msg.attachments
-
-    # Ignore bot messages (TODO: make this support an option?)
-    return if msg.subtype is 'bot_message'
-
-    # Ignore message subtypes that don't have a top level user property
-    return if not msg.user
-
     # Ignore our own messages
     return if msg.user == @self.id
 
-    channel = @client.getChannelGroupOrDMByID msg.channel
+    channel = @client.getChannelGroupOrDMByID msg.channel if msg.channel
+
+    if msg.hidden or (not msg.text and not msg.attachments) or msg.subtype is 'bot_message' or not msg.user or not channel
+      # use a raw message, so scripts that care can still see these things
+
+      if msg.user
+        user = @robot.brain.userForId msg.user
+      else
+        # We need to fake a user because, at the very least, CatchAllMessage
+        # expects it to be there.
+        user = {}
+        user.name = msg.username if msg.username?
+      user.room = channel.name if channel
+
+      if msg.text? or msg.attachments
+        text = @removeFormatting msg.getBody()
+
+      if msg.subtype is 'bot_message'
+        @robot.logger.debug "Received bot message: '#{text}' in channel: #{channel?.name}, from: #{user?.name}"
+        @receive new SlackBotMessage user, text, msg
+      else
+        @robot.logger.debug "Received raw message (subtype: #{msg.subtype})"
+        @receive new SlackRawMessage user, text, msg
+      return
 
     # Process the user into a full hubot user
     user = @robot.brain.userForId msg.user
@@ -122,17 +138,16 @@ class SlackBot extends Adapter
 
     else
       # Build message text to respond to, including all attachments
-      txt = msg.getBody()
+      rawText = msg.getBody()
+      text = @removeFormatting rawText
 
-      txt = @removeFormatting txt
-
-      @robot.logger.debug "Received message: '#{txt}' in channel: #{channel.name}, from: #{user.name}"
+      @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, from: #{user.name}"
 
       # If this is a DM, pretend it was addressed to us
       if msg.getChannelType() == 'DM'
-        txt = "#{@robot.name} #{txt}"
+        text = "#{@robot.name} #{text}"
 
-      @receive new TextMessage user, txt, msg.ts
+      @receive new SlackTextMessage user, text, rawText, msg.ts
 
   removeFormatting: (text) ->
     # https://api.slack.com/docs/formatting
@@ -227,8 +242,4 @@ class SlackBot extends Adapter
     channel = @client.getChannelGroupOrDMByName envelope.room
     channel.setTopic strings.join "\n"
 
-exports.use = (robot) ->
-  new SlackBot robot
-
-# Export class for unit tests
-exports.SlackBot = SlackBot
+module.exports = SlackBot

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -10,7 +10,15 @@ class ClientMessage
     @[k] = val for own k, val of fields
 
   getBody: ->
-    @text ? ""
+    # match what slack-client.Message does
+    text = ""
+    text += @text if @text
+    if @attachments
+      text += "\n" if @text
+      for k, attach of @attachments
+        text += "\n" if k > 0
+        text += attach.fallback
+    text
 
   getChannelType: ->
     # we only simulate channels for now
@@ -28,9 +36,9 @@ describe 'Receiving a Slack message', ->
       user: @stubs.user.id
       text: "Hello world"
     }
-    @stubs.robot.received.should.have.length(1)
+    @stubs.robot.received.should.have.length 1
     msg = @stubs.robot.received[0]
-    msg.should.be.an.instanceOf(SlackTextMessage)
+    msg.should.be.an.instanceOf SlackTextMessage
     msg.text.should.equal "Hello world"
 
   it 'should parse the text in the SlackTextMessage', ->
@@ -38,8 +46,89 @@ describe 'Receiving a Slack message', ->
       user: @stubs.user.id
       text: "Foo <@U123> bar <http://slack.com>"
     }
-    @stubs.robot.received.should.have.length(1)
+    @stubs.robot.received.should.have.length 1
     msg = @stubs.robot.received[0]
-    msg.should.be.an.instanceOf(SlackTextMessage)
+    msg.should.be.an.instanceOf SlackTextMessage
     msg.text.should.equal "Foo @name bar http://slack.com"
     msg.rawText.should.equal "Foo <@U123> bar <http://slack.com>"
+
+  it 'should include attachments in the SlackTextMessage text', ->
+    @slackbot.message @makeMessage {
+      user: @stubs.user.id
+      text: "Hello world"
+      attachments: [
+        { fallback: "attachment fallback" }
+        { fallback: "second attachment fallback" }
+      ]
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackTextMessage
+    msg.text.should.equal "Hello world\nattachment fallback\nsecond attachment fallback"
+
+  it 'should save the raw message in the SlackTextMessage', ->
+    @slackbot.message rawMsg = @makeMessage {
+      subtype: 'file_share'
+      user: @stubs.user.id
+      text: "Hello world"
+      file:
+        name: "file.txt"
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackTextMessage
+    msg.rawMessage.should.equal rawMsg
+
+  it 'should produce a SlackBotMessage when the subtype is bot_message', ->
+    @slackbot.message rawMsg = @makeMessage {
+      subtype: 'bot_message'
+      username: 'bot'
+      text: 'Hello world'
+      attachments: [{
+        fallback: 'attachment'
+      }]
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackBotMessage
+    msg.text.should.equal "Hello world\nattachment"
+    msg.rawMessage.should.equal rawMsg
+
+  it 'should produce a SlackRawMessage when the user is nil', ->
+    @slackbot.message rawMsg = @makeMessage {
+      text: 'Hello world'
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackRawMessage
+    msg.text.should.equal 'Hello world'
+    msg.rawMessage.should.equal rawMsg
+
+  it 'should produce a SlackRawMessage when the message is hidden', ->
+    @slackbot.message @makeMessage {
+      hidden: true
+      user: @stubs.user.id
+      text: 'Hello world'
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackRawMessage
+
+  it 'should produce a SlackRawMessage when the message has no body', ->
+    @slackbot.message @makeMessage {
+      user: @stubs.user.id
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackRawMessage
+
+  it 'should produce a SlackRawMessage when the message has no channel', ->
+    @slackbot.message new ClientMessage {
+      type: 'message'
+      user: @stubs.user.id
+      text: 'Hello world'
+      ts: "1234"
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackRawMessage

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -1,0 +1,45 @@
+{SlackTextMessage, SlackRawMessage, SlackBotMessage, SlackRawListener, SlackBotListener} = require '../index'
+
+should = require 'should'
+
+class ClientMessage
+  ts = 0
+  constructor: (fields = {}) ->
+    @type = 'message'
+    @ts = (ts++).toString()
+    @[k] = val for own k, val of fields
+
+  getBody: ->
+    @text ? ""
+
+  getChannelType: ->
+    # we only simulate channels for now
+    'Channel'
+
+describe 'Receiving a Slack message', ->
+  beforeEach ->
+    @makeMessage = (fields = {}) =>
+      msg = new ClientMessage fields
+      msg.channel = @stubs.channel.id unless 'channel' of fields
+      msg
+
+  it 'should produce a SlackTextMessage', ->
+    @slackbot.message @makeMessage {
+      user: @stubs.user.id
+      text: "Hello world"
+    }
+    @stubs.robot.received.should.have.length(1)
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf(SlackTextMessage)
+    msg.text.should.equal "Hello world"
+
+  it 'should parse the text in the SlackTextMessage', ->
+    @slackbot.message @makeMessage {
+      user: @stubs.user.id
+      text: "Foo <@U123> bar <http://slack.com>"
+    }
+    @stubs.robot.received.should.have.length(1)
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf(SlackTextMessage)
+    msg.text.should.equal "Foo @name bar http://slack.com"
+    msg.rawText.should.equal "Foo <@U123> bar <http://slack.com>"

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -9,9 +9,8 @@ should = require 'should'
 # Stub a few interfaces to grease the skids for tests. These are intentionally
 # as minimal as possible and only provide enough to make the tests possible.
 # Stubs are recreated before each test.
-stubs = null
 beforeEach ->
-  stubs =
+  @stubs =
     # Slack client
     channel:
       name: 'general'
@@ -19,10 +18,10 @@ beforeEach ->
     client:
       getUserByID: (id) ->
         {name: 'name', email_address: 'email@example.com'}
-      getChannelByID: (id) ->
-        stubs.channel
-      getChannelGroupOrDMByName: () ->
-        stubs.channel
+      getChannelByID: (id) =>
+        @stubs.channel
+      getChannelGroupOrDMByName: () =>
+        @stubs.channel
     # Hubot.Robot instance
     robot:
       logger:
@@ -30,10 +29,9 @@ beforeEach ->
         debug: ->
 
 # Generate a new slack instance for each test.
-slackbot = null
 beforeEach ->
-  slackbot = new SlackBot stubs.robot
-  slackbot.client = stubs.client
+  @slackbot = new SlackBot @stubs.robot
+  @slackbot.client = @stubs.client
 
 
 ###################################################################
@@ -41,7 +39,7 @@ beforeEach ->
 ###################################################################
 describe 'Adapter', ->
   it 'Should initialize with a robot', ->
-    slackbot.robot.should.eql stubs.robot
+    @slackbot.robot.should.eql @stubs.robot
 
 describe 'Login', ->
   it 'Should set the robot name', ->
@@ -49,85 +47,85 @@ describe 'Login', ->
       name: 'Test Team'
     user =
       name: 'bot'
-    slackbot.loggedIn(user, team)
-    slackbot.robot.name.should.equal 'bot'
+    @slackbot.loggedIn(user, team)
+    @slackbot.robot.name.should.equal 'bot'
 
 describe 'Removing message formatting', ->
   it 'Should do nothing if there are no user links', ->
-    foo = slackbot.removeFormatting 'foo'
+    foo = @slackbot.removeFormatting 'foo'
     foo.should.equal 'foo'
 
   it 'Should decode entities', ->
-    foo = slackbot.removeFormatting 'foo &gt; &amp; &lt; &gt;&amp;&lt;'
+    foo = @slackbot.removeFormatting 'foo &gt; &amp; &lt; &gt;&amp;&lt;'
     foo.should.equal 'foo > & < >&<'
 
   it 'Should change <@U1234> links to @name', ->
-    foo = slackbot.removeFormatting 'foo <@U123> bar'
+    foo = @slackbot.removeFormatting 'foo <@U123> bar'
     foo.should.equal 'foo @name bar'
 
   it 'Should change <@U1234|label> links to label', ->
-    foo = slackbot.removeFormatting 'foo <@U123|label> bar'
+    foo = @slackbot.removeFormatting 'foo <@U123|label> bar'
     foo.should.equal 'foo label bar'
 
   it 'Should change <#C1234> links to #general', ->
-    foo = slackbot.removeFormatting 'foo <#C123> bar'
+    foo = @slackbot.removeFormatting 'foo <#C123> bar'
     foo.should.equal 'foo #general bar'
 
   it 'Should change <#C1234|label> links to label', ->
-    foo = slackbot.removeFormatting 'foo <#C123|label> bar'
+    foo = @slackbot.removeFormatting 'foo <#C123|label> bar'
     foo.should.equal 'foo label bar'
 
   it 'Should change <!everyone> links to @everyone', ->
-    foo = slackbot.removeFormatting 'foo <!everyone> bar'
+    foo = @slackbot.removeFormatting 'foo <!everyone> bar'
     foo.should.equal 'foo @everyone bar'
 
   it 'Should change <!channel> links to @channel', ->
-    foo = slackbot.removeFormatting 'foo <!channel> bar'
+    foo = @slackbot.removeFormatting 'foo <!channel> bar'
     foo.should.equal 'foo @channel bar'
 
   it 'Should change <!group> links to @group', ->
-    foo = slackbot.removeFormatting 'foo <!group> bar'
+    foo = @slackbot.removeFormatting 'foo <!group> bar'
     foo.should.equal 'foo @group bar'
 
   it 'Should remove formatting around <http> links', ->
-    foo = slackbot.removeFormatting 'foo <http://www.example.com> bar'
+    foo = @slackbot.removeFormatting 'foo <http://www.example.com> bar'
     foo.should.equal 'foo http://www.example.com bar'
 
   it 'Should remove formatting around <https> links', ->
-    foo = slackbot.removeFormatting 'foo <https://www.example.com> bar'
+    foo = @slackbot.removeFormatting 'foo <https://www.example.com> bar'
     foo.should.equal 'foo https://www.example.com bar'
 
   it 'Should remove formatting around <skype> links', ->
-    foo = slackbot.removeFormatting 'foo <skype:echo123?call> bar'
+    foo = @slackbot.removeFormatting 'foo <skype:echo123?call> bar'
     foo.should.equal 'foo skype:echo123?call bar'
 
   it 'Should remove formatting around <https> links with a label', ->
-    foo = slackbot.removeFormatting 'foo <https://www.example.com|label> bar'
+    foo = @slackbot.removeFormatting 'foo <https://www.example.com|label> bar'
     foo.should.equal 'foo label (https://www.example.com) bar'
 
   it 'Should remove formatting around <https> links with a substring label', ->
-    foo = slackbot.removeFormatting 'foo <https://www.example.com|example.com> bar'
+    foo = @slackbot.removeFormatting 'foo <https://www.example.com|example.com> bar'
     foo.should.equal 'foo https://www.example.com bar'
 
   it 'Should remove formatting around <https> links with a label containing entitles', ->
-    foo = slackbot.removeFormatting 'foo <https://www.example.com|label &gt; &amp; &lt;> bar'
+    foo = @slackbot.removeFormatting 'foo <https://www.example.com|label &gt; &amp; &lt;> bar'
     foo.should.equal 'foo label > & < (https://www.example.com) bar'
 
   it 'Should remove formatting around <mailto> links', ->
-    foo = slackbot.removeFormatting 'foo <mailto:name@example.com> bar'
+    foo = @slackbot.removeFormatting 'foo <mailto:name@example.com> bar'
     foo.should.equal 'foo name@example.com bar'
 
   it 'Should remove formatting around <mailto> links with an email label', ->
-    foo = slackbot.removeFormatting 'foo <mailto:name@example.com|name@example.com> bar'
+    foo = @slackbot.removeFormatting 'foo <mailto:name@example.com|name@example.com> bar'
     foo.should.equal 'foo name@example.com bar'
 
   it 'Should change multiple links at once', ->
-    foo = slackbot.removeFormatting 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'
+    foo = @slackbot.removeFormatting 'foo <@U123|label> bar <#C123> <!channel> <https://www.example.com|label>'
     foo.should.equal 'foo label bar #general @channel label (https://www.example.com)'
 
 describe 'Send Messages', ->
   it 'Should send multiple messages', ->
-    sentMessages = slackbot.send {room: 'room-name'}, 'one', 'two', 'three'
+    sentMessages = @slackbot.send {room: 'room-name'}, 'one', 'two', 'three'
     sentMessages.length.should.equal 3
 
   it 'Should split long messages', ->
@@ -137,20 +135,20 @@ describe 'Send Messages', ->
     len = 10000
     msg += lines while msg.length < len
 
-    sentMessages = slackbot.send {room: 'room-name'}, msg
+    sentMessages = @slackbot.send {room: 'room-name'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.length.should.equal Math.ceil(len / SlackBot.MAX_MESSAGE_LENGTH)
 
   it 'Should try to split on word breaks', ->
     msg = 'Foo bar baz'
-    slackbot.constructor.MAX_MESSAGE_LENGTH = 10
-    sentMessages = slackbot.send {room: 'room-name'}, msg
+    @slackbot.constructor.MAX_MESSAGE_LENGTH = 10
+    sentMessages = @slackbot.send {room: 'room-name'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.length.should.equal 2
 
   it 'Should split into max length chunks if there are no breaks', ->
     msg = 'Foobar'
-    slackbot.constructor.MAX_MESSAGE_LENGTH = 3
-    sentMessages = slackbot.send {room: 'room-name'}, msg
+    @slackbot.constructor.MAX_MESSAGE_LENGTH = 3
+    sentMessages = @slackbot.send {room: 'room-name'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.should.eql ['Foo', 'bar']

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -90,7 +90,7 @@ describe 'Removing message formatting', ->
 
 describe 'Send Messages', ->
   it 'Should send multiple messages', ->
-    sentMessages = @slackbot.send {room: 'room-name'}, 'one', 'two', 'three'
+    sentMessages = @slackbot.send {room: 'general'}, 'one', 'two', 'three'
     sentMessages.length.should.equal 3
 
   it 'Should split long messages', ->
@@ -100,20 +100,20 @@ describe 'Send Messages', ->
     len = 10000
     msg += lines while msg.length < len
 
-    sentMessages = @slackbot.send {room: 'room-name'}, msg
+    sentMessages = @slackbot.send {room: 'general'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.length.should.equal Math.ceil(len / SlackBot.MAX_MESSAGE_LENGTH)
 
   it 'Should try to split on word breaks', ->
     msg = 'Foo bar baz'
     @slackbot.constructor.MAX_MESSAGE_LENGTH = 10
-    sentMessages = @slackbot.send {room: 'room-name'}, msg
+    sentMessages = @slackbot.send {room: 'general'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.length.should.equal 2
 
   it 'Should split into max length chunks if there are no breaks', ->
     msg = 'Foobar'
     @slackbot.constructor.MAX_MESSAGE_LENGTH = 3
-    sentMessages = @slackbot.send {room: 'room-name'}, msg
+    sentMessages = @slackbot.send {room: 'general'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.should.eql ['Foo', 'bar']

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -24,19 +24,19 @@ describe 'Removing message formatting', ->
     foo = @slackbot.removeFormatting 'foo &gt; &amp; &lt; &gt;&amp;&lt;'
     foo.should.equal 'foo > & < >&<'
 
-  it 'Should change <@U1234> links to @name', ->
+  it 'Should change <@U123> links to @name', ->
     foo = @slackbot.removeFormatting 'foo <@U123> bar'
     foo.should.equal 'foo @name bar'
 
-  it 'Should change <@U1234|label> links to label', ->
+  it 'Should change <@U123|label> links to label', ->
     foo = @slackbot.removeFormatting 'foo <@U123|label> bar'
     foo.should.equal 'foo label bar'
 
-  it 'Should change <#C1234> links to #general', ->
+  it 'Should change <#C123> links to #general', ->
     foo = @slackbot.removeFormatting 'foo <#C123> bar'
     foo.should.equal 'foo #general bar'
 
-  it 'Should change <#C1234|label> links to label', ->
+  it 'Should change <#C123|label> links to label', ->
     foo = @slackbot.removeFormatting 'foo <#C123|label> bar'
     foo.should.equal 'foo label bar'
 
@@ -72,7 +72,7 @@ describe 'Removing message formatting', ->
     foo = @slackbot.removeFormatting 'foo <https://www.example.com|example.com> bar'
     foo.should.equal 'foo https://www.example.com bar'
 
-  it 'Should remove formatting around <https> links with a label containing entitles', ->
+  it 'Should remove formatting around <https> links with a label containing entities', ->
     foo = @slackbot.removeFormatting 'foo <https://www.example.com|label &gt; &amp; &lt;> bar'
     foo.should.equal 'foo label > & < (https://www.example.com) bar'
 

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -4,7 +4,7 @@
 should = require 'should'
 
 # Import our hero. Noop logging so that we don't clutter the test output
-{SlackBot} = require '../src/slack'
+{SlackBot} = require '../index'
 
 # Stub a few interfaces to grease the skids for tests. These are intentionally
 # as minimal as possible and only provide enough to make the tests possible.

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -1,42 +1,7 @@
-###################################################################
-# Setup the tests
-###################################################################
-should = require 'should'
-
-# Import our hero. Noop logging so that we don't clutter the test output
 {SlackBot} = require '../index'
 
-# Stub a few interfaces to grease the skids for tests. These are intentionally
-# as minimal as possible and only provide enough to make the tests possible.
-# Stubs are recreated before each test.
-beforeEach ->
-  @stubs =
-    # Slack client
-    channel:
-      name: 'general'
-      send: (msg) -> msg
-    client:
-      getUserByID: (id) ->
-        {name: 'name', email_address: 'email@example.com'}
-      getChannelByID: (id) =>
-        @stubs.channel
-      getChannelGroupOrDMByName: () =>
-        @stubs.channel
-    # Hubot.Robot instance
-    robot:
-      logger:
-        info: ->
-        debug: ->
+should = require 'should'
 
-# Generate a new slack instance for each test.
-beforeEach ->
-  @slackbot = new SlackBot @stubs.robot
-  @slackbot.client = @stubs.client
-
-
-###################################################################
-# Start the tests
-###################################################################
 describe 'Adapter', ->
   it 'Should initialize with a robot', ->
     @slackbot.robot.should.eql @stubs.robot

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -1,0 +1,31 @@
+# Setup stubs used by the other tests
+
+{SlackBot} = require '../index'
+
+# Stub a few interfaces to grease the skids for tests. These are intentionally
+# as minimal as possible and only provide enough to make the tests possible.
+# Stubs are recreated before each test.
+beforeEach ->
+  @stubs =
+    # Slack client
+    channel:
+      name: 'general'
+      send: (msg) -> msg
+    client:
+      getUserByID: (id) ->
+        {name: 'name', email_address: 'email@example.com'}
+      getChannelByID: (id) =>
+        @stubs.channel
+      getChannelGroupOrDMByName: () =>
+        @stubs.channel
+    # Hubot.Robot instance
+    robot:
+      # noop the logging
+      logger:
+        info: ->
+        debug: ->
+
+# Generate a new slack instance for each test.
+beforeEach ->
+  @slackbot = new SlackBot @stubs.robot
+  @slackbot.client = @stubs.client

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -1,31 +1,60 @@
 # Setup stubs used by the other tests
 
 {SlackBot} = require '../index'
+{EventEmitter} = require 'events'
+# Use Hubot's brain in our stubs
+{Brain} = require 'hubot'
 
 # Stub a few interfaces to grease the skids for tests. These are intentionally
 # as minimal as possible and only provide enough to make the tests possible.
 # Stubs are recreated before each test.
 beforeEach ->
-  @stubs =
-    # Slack client
-    channel:
-      name: 'general'
-      send: (msg) -> msg
-    client:
-      getUserByID: (id) ->
-        {name: 'name', email_address: 'email@example.com'}
-      getChannelByID: (id) =>
-        @stubs.channel
-      getChannelGroupOrDMByName: () =>
-        @stubs.channel
-    # Hubot.Robot instance
-    robot:
-      # noop the logging
-      logger:
-        info: ->
-        debug: ->
+  @stubs = {}
+  @stubs.channel =
+    name: 'general'
+    id: 'C123'
+    send: (msg) -> msg
+  @stubs.user =
+    name: 'name'
+    id: 'U123'
+    profile:
+      email: 'email@example.com'
+  @stubs.self =
+    name: 'self'
+    id: 'U456'
+    profile:
+      email: 'self@example.com'
+  @stubs.team =
+    name: 'Example Team'
+  # Slack client
+  @stubs.client =
+    getUserByID: (id) =>
+      for user in @stubs.client.users
+        return user if user.id is id
+    getChannelByID: (id) =>
+      @stubs.channel if @stubs.channel.id == id
+    getChannelGroupOrDMByID: (id) =>
+      @stubs.channel if @stubs.channel.id == id
+    getChannelGroupOrDMByName: (name) =>
+      @stubs.channel if @stubs.channel.name == name
+    users: [@stubs.user, @stubs.self]
+  # Hubot.Robot instance
+  @stubs.robot = do ->
+    robot = new EventEmitter
+    # noop the logging
+    robot.logger =
+      info: ->
+      debug: ->
+    # record all received messages
+    robot.received = []
+    robot.receive = (msg) ->
+      @received.push msg
+    # attach a real Brain to the robot
+    robot.brain = new Brain robot
+    robot
 
 # Generate a new slack instance for each test.
 beforeEach ->
   @slackbot = new SlackBot @stubs.robot
   @slackbot.client = @stubs.client
+  @slackbot.loggedIn @stubs.self, @stubs.team


### PR DESCRIPTION
Regular text messages now use a TextMessage subclass called
SlackTextMessage, which includes both the parsed text (as `text`) and
the unparsed text (as `rawText`).

Other messages that used to be ignored are now received as either
SlackRawMessage or SlackBotMessage. These do not descend from
TextMessage so they won't be seen by normal `hear` or `respond`
listeners.

A few new Listener classes were created, SlackRawListener and
SlackBotListener, to make it slightly easier to write code tailored for
these new message types.

This PR is based on #131.