### PR TITLE
replace "#" from channel name prefix

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -191,7 +191,7 @@ class SlackBot extends Adapter
     text
 
   send: (envelope, messages...) ->
-    channel = @client.getChannelGroupOrDMByName envelope.room
+    channel = @client.getChannelGroupOrDMByName envelope.room.replace(/^#/,'')
 
     for msg in messages
       @robot.logger.debug "Sending to #{envelope.room}: #{msg}"
@@ -239,7 +239,7 @@ class SlackBot extends Adapter
       @send envelope, "#{envelope.user.name}: #{msg}"
 
   topic: (envelope, strings...) ->
-    channel = @client.getChannelGroupOrDMByName envelope.room
+    channel = @client.getChannelGroupOrDMByName envelope.room.replace(/^#/,'')
     channel.setTopic strings.join "\n"
 
 module.exports = SlackBot


### PR DESCRIPTION
This is an alternative implementation for #136

Some hubot-scripts using `robot.send("#room_name", msg)`.
It was ok at hubot-slack v2, but not works with current version (v3).