### PR TITLE
direct reply when using the `reply`

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -232,11 +232,10 @@ class SlackBot extends Adapter
         channel.send m for m in submessages
 
   reply: (envelope, messages...) ->
-    @robot.logger.debug "Sending reply"
+    @robot.logger.debug "Sending direct reply"
 
-    for msg in messages
-      # TODO: Don't prefix username if replying in DM
-      @send envelope, "#{envelope.user.name}: #{msg}"
+    user = @client.getDMByName envelope.user.name
+    user.send msg for msg in messages
 
   topic: (envelope, strings...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room


### PR DESCRIPTION

![hellocomputer](https://cloud.githubusercontent.com/assets/16054/5682381/95e3805e-97ed-11e4-9c36-4324a1619a7b.gif)


Instead of just replying with a username, why not make this more useful for quieting slack down a bit. 

Seems like the reply method is more of a holdover from chat clients w/o the DM functionality. `send` and `reply` are almost identical otherwise. Is this useful to anyone else? Open to other suggestions on how to make this happen.