### PR TITLE
use JSON.stringify to print Error object

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -40,7 +40,7 @@ class SlackBot extends Adapter
     @client.login()
 
   error: (error) =>
-    @robot.logger.error "Received error #{error.toString()}"
+    @robot.logger.error "Received error #{JSON.stringify error}"
     @robot.logger.error error.stack
     @robot.logger.error "Exiting in 1 second"
     setTimeout process.exit.bind(process, 1), 1000


### PR DESCRIPTION
## bug
I could not read error's detail, because it is using `toString()`.

```
[Sun Jan 11 2015 16:51:34 GMT+0900 (JST)] ERROR Received error [object Object]
```

## fixed

use JSON.stringify to print error object.
```
[Sun Jan 11 2015 16:59:42 GMT+0900 (JST)] ERROR Received error {"code":-1,"msg":"slow down, too many messages..."}
```