### PR TITLE
Add back support for Slack attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "test": "mocha --compilers coffee:coffee-script/register --reporter spec"
   },
   "dependencies": {
-    "slack-client": "~1.2.0"
+    "slack-client": "~1.4.0"
   }
 }


### PR DESCRIPTION
This pull request reimplements slack attachment support in Hubot.

It does so using an as-yet undocumented Slack API, where chat.postMessage will now accept an `as_user` boolean argument. Even though this API has been deployed to our production servers, **_it should be considered provisional and the details may change_**. We'll be documenting it on api.slack.com and confirm here when we're confident that the design is right.

I believe this is compatible with both scripts that used hubot-slack v2's attachment support, and scripts that use @inkel's [hubot-slack-attachment](inkel/hubot-slack-attachment) script. But, I don't have many test cases, so I may have missed something.

I'm looking for feedback on whether this approach makes sense, and bug reports where the attachment support doesn't work with existing scripts.