### PR TITLE
ignore empty message

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -194,6 +194,8 @@ class SlackBot extends Adapter
     channel = @client.getChannelGroupOrDMByName envelope.room
 
     for msg in messages
+      continue if msg.length is 0
+
       @robot.logger.debug "Sending to #{envelope.room}: #{msg}"
 
       if msg.length <= SlackBot.MAX_MESSAGE_LENGTH


### PR DESCRIPTION
The `hubot-slack@3.2.1` has crashed by sending an empty message. See commit.

Script:

```
module.exports = (robot) ->
  robot.respond /hello/, (res) ->
    res.send '' # empty string
```

Log:

```
[Tue Feb 17 2015 21:17:04 GMT+0900 (JST)] ERROR Received error [object Object]
[Tue Feb 17 2015 21:17:04 GMT+0900 (JST)] ERROR undefined
[Tue Feb 17 2015 21:17:04 GMT+0900 (JST)] ERROR Exiting in 1 second
```

API response: 

```
{ code: 2, msg: 'message text is missing' }
```
