### PR TITLE
Fixes to slack.attachment support

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -265,7 +265,7 @@ class SlackBot extends Adapter
 
     msg.text = data.text
 
-    if data.username && data.username != robot.name
+    if data.username && data.username != @robot.name
       msg.as_user = false
       if data.icon_url?
         msg.icon_url = data.icon_url

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -267,6 +267,7 @@ class SlackBot extends Adapter
 
     if data.username && data.username != @robot.name
       msg.as_user = false
+      msg.username = data.username
       if data.icon_url?
         msg.icon_url = data.icon_url
       else if data.icon_emoji?


### PR DESCRIPTION
When attempting to emit slack.attachment from a router response in our hubot, I saw the dreaded `ReferenceError: robot is not defined` error in the logs. I updated the customMessage function to check the passed username with `@robot.name` rather than `robot.name`.

Then I noticed by passed name wasn't working (was showing up as 'Bot'). Fixed that too. :wink:

Works great now! Thanks for adding support for attachments back into the adapter!