### PR TITLE
Allow sending DMs to arbitrary users

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -197,6 +197,12 @@ class SlackBot extends Adapter
   send: (envelope, messages...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room
 
+    if not channel and @client.getUserByName(envelope.room)
+      user_id = @client.getUserByName(envelope.room).id
+      @client.openDM user_id, =>
+        this.send envelope, messages...
+      return
+
     for msg in messages
       continue if msg.length < SlackBot.MIN_MESSAGE_LENGTH
 

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -121,3 +121,13 @@ describe 'Send Messages', ->
     sentMessages = @slackbot.send {room: 'general'}, msg
     sentMessage = sentMessages.pop()
     sentMessage.should.eql ['Foo', 'bar']
+
+  it 'Should open a DM channel if needed', ->
+    msg = 'Test'
+    @slackbot.send {room: 'name'}, msg
+    @stubs._msg.should.eql 'Test'
+
+  it 'Should use an existing DM channel if possible', ->
+    msg = 'Test'
+    @slackbot.send {room: 'user2'}, msg
+    @stubs._dmmsg.should.eql 'Test'

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -31,13 +31,35 @@ beforeEach ->
     getUserByID: (id) =>
       for user in @stubs.client.users
         return user if user.id is id
+    getUserByName: (name) =>
+      for user in @stubs.client.users
+        return user if user.name is name
     getChannelByID: (id) =>
       @stubs.channel if @stubs.channel.id == id
     getChannelGroupOrDMByID: (id) =>
       @stubs.channel if @stubs.channel.id == id
     getChannelGroupOrDMByName: (name) =>
-      @stubs.channel if @stubs.channel.name == name
+      return @stubs.channel if @stubs.channel.name == name
+      for dm in @stubs.client.dms
+        return dm if dm.name is name
+    openDM: (user_id, callback) =>
+      user = @stubs.client.getUserByID user_id
+      @stubs.client.dms.push {
+        name: user.name,
+        id: 'D1234',
+        send: (msg) =>
+          @stubs._msg = if @stubs._msg then @stubs._msg + msg else msg
+        }
+      callback?()
     users: [@stubs.user, @stubs.self]
+    dms: [
+      {
+        name: 'user2',
+        id: 'D5432',
+        send: (msg) =>
+          @stubs._dmmsg = if @stubs._dmmsg then @stubs._dmmsg + msg else msg
+      }
+    ]
   # Hubot.Robot instance
   @stubs.robot = do ->
     robot = new EventEmitter


### PR DESCRIPTION
This change uses the new callbacks available in node-slack-client. If
robot.send is called like:

robot.send {room: 'someuser'}, 'message'

If someuser is a user and there is no existing DM, it will use openDM to
establish a new private message with the user and send the message in the
callback.