### PR TITLE
Copy edit for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ need to upgrade:
 - Update your production startup scripts to pass the new `HUBOT_SLACK_TOKEN`.
   You can remove the other `HUBOT_SLACK_*` environment variables if you want.
 - Deploy your new hubot to production.
-- Once you're happy it works, remove the old hubot integration from
+- Once you're happy it works, disable the old hubot integration from
   https://my.slack.com/services
 
 ## Configuration


### PR DESCRIPTION
The current language around removing the old hubot integration implies that you can actually delete the integration, which is confusing. I went searching all over for a way to "delete" or "remove" him, since all I could find in the UI was an option to "disable". Eventually I discovered #147 which clarifies that you cannot actually delete or remove old integrations, only disable. So updating the language in the README here would be helpful. :sparkles: