### PR TITLE
Add support for @mentioning users in hubot message

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -193,6 +193,8 @@ class SlackBot extends Adapter
 
   send: (envelope, messages...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room
+    # Had scoping issue and only got it to work with this
+    client = @client
 
     if not channel and @client.getUserByName(envelope.room)
       user_id = @client.getUserByName(envelope.room).id
@@ -202,6 +204,14 @@ class SlackBot extends Adapter
 
     for msg in messages
       continue if msg.length < SlackBot.MIN_MESSAGE_LENGTH
+
+      # Replace @username with <@UXXXXX> for mentioning users
+      msg = msg.replace /(?:^@| @)([A-z]+)/gm, (match, p1) ->
+        try 
+          user_id = client.getUserByName(p1).id
+          match = ' <@' + user_id + '>'
+        catch
+          match = match
 
       @robot.logger.debug "Sending to #{envelope.room}: #{msg}"
 

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -193,7 +193,6 @@ class SlackBot extends Adapter
 
   send: (envelope, messages...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room
-    # Had scoping issue and only got it to work with this
 
     if not channel and @client.getUserByName(envelope.room)
       user_id = @client.getUserByName(envelope.room).id

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -205,13 +205,10 @@ class SlackBot extends Adapter
 
       # Replace @username with <@UXXXXX> for mentioning users and channels
       msg = msg.replace /(?:^| )@([\w]+)/gm, (match, p1) =>
-        console.log "Match: #{match}"
-        console.log "P1: #{p1}"
         user = @client.getUserByName p1
-        console.log "User: #{user}"
         if user
           match = match.replace /@[\w]+/, "<@#{user.id}>"
-        else if p1 is 'channel' or 'everyone' or 'group'
+        else if (p1 is 'channel' or p1 is 'everyone' or p1 is 'group')
           match = match.replace /@[\w]+/, "<!#{p1}>"
         else
           match = match

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -194,7 +194,6 @@ class SlackBot extends Adapter
   send: (envelope, messages...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room
     # Had scoping issue and only got it to work with this
-    client = @client
 
     if not channel and @client.getUserByName(envelope.room)
       user_id = @client.getUserByName(envelope.room).id
@@ -206,9 +205,9 @@ class SlackBot extends Adapter
       continue if msg.length < SlackBot.MIN_MESSAGE_LENGTH
 
       # Replace @username with <@UXXXXX> for mentioning users
-      msg = msg.replace /(?:^@| @)([A-z]+)/gm, (match, p1) ->
+      msg = msg.replace /(?:^@| @)([A-z]+)/gm, (match, p1) =>
         try 
-          user_id = client.getUserByName(p1).id
+          user_id = @client.getUserByName(p1).id
           match = ' <@' + user_id + '>'
         catch
           match = match

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -255,7 +255,7 @@ class SlackBot extends Adapter
 
     for msg in messages
       # TODO: Don't prefix username if replying in DM
-      @send envelope, "#{envelope.user.name}: #{msg}"
+      @send envelope, "@#{envelope.user.name}: #{msg}"
 
   topic: (envelope, strings...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -204,12 +204,15 @@ class SlackBot extends Adapter
       continue if msg.length < SlackBot.MIN_MESSAGE_LENGTH
 
       # Replace @username with <@UXXXXX> for mentioning users and channels
-      msg = msg.replace /(?:^@| @)([A-z]+)/gm, (match, p1) =>
-        user = @client.getUserByName(p1)
+      msg = msg.replace /(?:^| )@([\w]+)/gm, (match, p1) =>
+        console.log "Match: #{match}"
+        console.log "P1: #{p1}"
+        user = @client.getUserByName p1
+        console.log "User: #{user}"
         if user
-          match = " <@#{user.id}>"
+          match = match.replace /@[\w]+/, "<@#{user.id}>"
         else if p1 is 'channel' or 'everyone' or 'group'
-          match = " <!#{p1}>"
+          match = match.replace /@[\w]+/, "<!#{p1}>"
         else
           match = match
 

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -203,12 +203,14 @@ class SlackBot extends Adapter
     for msg in messages
       continue if msg.length < SlackBot.MIN_MESSAGE_LENGTH
 
-      # Replace @username with <@UXXXXX> for mentioning users
+      # Replace @username with <@UXXXXX> for mentioning users and channels
       msg = msg.replace /(?:^@| @)([A-z]+)/gm, (match, p1) =>
-        try 
-          user_id = @client.getUserByName(p1).id
-          match = ' <@' + user_id + '>'
-        catch
+        user = @client.getUserByName(p1)
+        if user
+          match = " <@#{user.id}>"
+        else if p1 is 'channel' or 'everyone' or 'group'
+          match = " <!#{p1}>"
+        else
           match = match
 
       @robot.logger.debug "Sending to #{envelope.room}: #{msg}"

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -108,6 +108,48 @@ describe 'Send Messages', ->
     sentMessage = sentMessages.pop()
     sentMessage.length.should.equal Math.ceil(len / SlackBot.MAX_MESSAGE_LENGTH)
 
+  it 'Should replace @name with <@U123> for mention', ->
+    msg = 'foo @name: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <@U123>: bar'
+
+  it 'Should replace @name with <@U123> for mention (first word)', ->
+    msg = '@name: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal '<@U123>: bar'
+
+  it 'Should replace @name with <@U123> for mention (without colons)', ->
+    msg = 'foo @name bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <@U123> bar'
+
+  it 'Should replace @channel with <!channel> for mention', ->
+    msg = 'foo @channel: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <!channel>: bar'
+
+  it 'Should replace multiple mentions with <!XXXX>', ->
+    msg = 'foo @everyone: @channel: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <!everyone>: <!channel>: bar'
+
+  it 'Should replace multiple mentions with <!XXXX>/<@UXXXX>', ->
+    msg = 'foo @everyone: @name: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <!everyone>: <@U123>: bar'
+
+  it 'Should not replace @name with <@U123> for mention when there is a typo', ->
+    msg = 'foo @nae: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo @nae: bar'
+
   it 'Should try to split on word breaks', ->
     msg = 'Foo bar baz'
     @slackbot.constructor.MAX_MESSAGE_LENGTH = 10

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -145,10 +145,10 @@ describe 'Send Messages', ->
     sentMessage.should.equal 'foo <!everyone>: <@U123>: bar'
 
   it 'Should not replace @name with <@U123> for mention when there is a typo', ->
-    msg = 'foo @nae: bar'
+    msg = 'foo @naame: bar'
     sentMessages = @slackbot.send {room: 'general'}, msg
     sentMessage = sentMessages.pop()
-    sentMessage.should.equal 'foo @nae: bar'
+    sentMessage.should.equal 'foo @naame: bar'
 
   it 'Should try to split on word breaks', ->
     msg = 'Foo bar baz'


### PR DESCRIPTION
Feature from #132 

Not sure if this is the right way to go about adding this feature but I did it for our company bot and figured others would like the feature as well.  I implemented in the send method so that you only need to prefix usernames with @ in your scripts and the when it goes through the adapter's send method the `@username` gets replaced with `<@UXXXXX>` to mention a user.  If the the user does not exist then the `@username` gets sent without actually mentioning or sending notification.  

FIXED:
Also I had a weird scoping issue with `@client` (I'm not super familiar with coffeescript) but solved it by making a copy (eg. `client = @client`) if anyone knows a better way to solve that I would be happy to change it