### PR TITLE
`addons:add` is now `addons:create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is a modified set of instructions based on the [instructions on the Hubot w
 
 - Install [heroku toolbelt](https://toolbelt.heroku.com/) if you haven't already.
 - `heroku create my-company-slackbot`
-- `heroku addons:add redistogo:nano`
+- `heroku addons:create redistogo:nano`
 - Activate the Hubot service on your ["Team Services"](http://my.slack.com/services/new/hubot) page inside Slack.
 - Add the [config variables](#adapter-configuration). For example:
 


### PR DESCRIPTION
Heroku warns:

> WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead.