### PR TITLE
If Slack client closes, exit the hubot process

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -13,14 +13,14 @@ class SlackBot extends Adapter
     @robot = robot
 
   run: ->
-    exit_process_on_disconnect = !!process.env.HUBOT_SLACK_EXIT_ON_DISCONNECT
+    exitProcessOnDisconnect = !!process.env.HUBOT_SLACK_EXIT_ON_DISCONNECT
 
     # Take our options from the environment, and set otherwise suitable defaults
     options =
       token: process.env.HUBOT_SLACK_TOKEN
-      autoReconnect: !exit_process_on_disconnect
+      autoReconnect: !exitProcessOnDisconnect
       autoMark: true
-      exitOnDisconnect: exit_process_on_disconnect
+      exitOnDisconnect: exitProcessOnDisconnect
 
     return @robot.logger.error "No services token provided to Hubot" unless options.token
     return @robot.logger.error "v2 services token provided, please follow the upgrade instructions" unless (options.token.substring(0, 5) in ['xoxb-', 'xoxp-'])

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -16,7 +16,7 @@ class SlackBot extends Adapter
     # Take our options from the environment, and set otherwise suitable defaults
     options =
       token: process.env.HUBOT_SLACK_TOKEN
-      autoReconnect: true
+      autoReconnect: false
       autoMark: true
 
     return @robot.logger.error "No services token provided to Hubot" unless options.token
@@ -88,8 +88,14 @@ class SlackBot extends Adapter
     @emit "connected"
 
   clientClose: =>
-    # Don't actually do anything since we may reconnect in the future
-    @robot.logger.info 'Slack client closed, waiting for reconnect'
+    @robot.logger.info 'Slack client connection was closed, exiting hubot process'
+    @client.removeListener 'error', @.error
+    @client.removeListener 'loggedIn', @.loggedIn
+    @client.removeListener 'open', @.open
+    @client.removeListener 'close', @.clientClose
+    @client.removeListener 'message', @.message
+    @client.removeListener 'userChange', @.userChange
+    process.exit 1
 
   message: (msg) =>
     # Ignore our own messages


### PR DESCRIPTION
Since Slack client seems to have troubles reconnecting occasionally (e.g. slackhq/hubot-slack#203), this seems like the only way to solve it right now. I'm running Hubot using supervisor and in the case of Slack client dropping its connection it seems to me that having the Hubot process exit and get restarted from e.g. supervisor is the way to go.