### PR TITLE
Add a notice to @here.

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -177,7 +177,7 @@ class SlackBot extends Adapter
             return "\##{channel.name}"
 
         when '!'
-          if link in ['channel','group','everyone']
+          if link in ['channel','group','everyone','here']
             return "@#{link}"
 
         else

--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -52,6 +52,10 @@ describe 'Removing message formatting', ->
     foo = @slackbot.removeFormatting 'foo <!group> bar'
     foo.should.equal 'foo @group bar'
 
+  it 'Should change <!here> links to @here', ->
+    foo = @slackbot.removeFormatting 'foo <!here> bar'
+    foo.should.equal 'foo @here bar'
+
   it 'Should remove formatting around <http> links', ->
     foo = @slackbot.removeFormatting 'foo <http://www.example.com> bar'
     foo.should.equal 'foo http://www.example.com bar'


### PR DESCRIPTION
`@here` is added to the notification method of Slack.
https://slack.zendesk.com/hc/en-us/articles/202009646-Making-announcements

