### PR TITLE
moves hubot out of devDependencies and into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "should": "~2.0.2",
     "mocha": "~1.13.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-shell": "~0.5.0",
-    "hubot": "~2.11"
+    "grunt-shell": "~0.5.0"
   },
   "main": "./index",
   "engines": {
@@ -67,6 +66,7 @@
     "test": "mocha --compilers coffee:coffee-script/register --reporter spec"
   },
   "dependencies": {
-    "slack-client": "~1.4.0"
+    "slack-client": "~1.4.0",
+    "hubot": "~2.11"
   }
 }


### PR DESCRIPTION
This fixes #225.

`hubot` was in the `devDependencies` rather than the `dependencies`. When someone installs only the production dependencies (`npm install --production`), this core dependency is not included.

