### PR TITLE
Persist more user data from Slack in the brain

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -73,7 +73,17 @@ class SlackBot extends Adapter
       if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
-    newUser = {name: user.name, real_name: user.real_name, email_address: user.profile.email}
+    newUser =
+      name: user.name
+      real_name: user.real_name
+      email_address: user.profile.email
+      slack: {}
+    for key, value of user
+      # _client is the slack-client instance and contains references to the all the data types (users, channels) plus things like the token, s
+      # so, don't bother storing it
+      continue if key is '_client'
+      newUser.slack[key] = value
+
     if user.id of @robot.brain.data.users
       for key, value of @robot.brain.data.users[user.id]
         unless key of newUser

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -79,8 +79,8 @@ class SlackBot extends Adapter
       email_address: user.profile.email
       slack: {}
     for key, value of user
-      # user contains an of the SlackClient, which and contains references to the all the data types (users, channels) plus things like the token, s
-      # so, don't bother storing it
+      # don't store the SlackClient, because it'd cause a circular reference
+      # (it contains users and channels), and because it has sensitive information like the token
       continue if value instanceof SlackClient
       newUser.slack[key] = value
 

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -79,9 +79,9 @@ class SlackBot extends Adapter
       email_address: user.profile.email
       slack: {}
     for key, value of user
-      # _client is the slack-client instance and contains references to the all the data types (users, channels) plus things like the token, s
+      # user contains an of the SlackClient, which and contains references to the all the data types (users, channels) plus things like the token, s
       # so, don't bother storing it
-      continue if key is '_client'
+      continue if value instanceof SlackClient
       newUser.slack[key] = value
 
     if user.id of @robot.brain.data.users


### PR DESCRIPTION
I wanted access to more details about a user in order to write [listener middleware](https://hubot.github.com/docs/scripting/#listener-middleware) for doing things like blocking access for restricted and bot users.

The data is there in hubot-slack, but just not put into hubot's brain. I had considered just adding everything to the user object at the top level, but I think it'd be better to namespace it under `slack`, so it doesn't seem like that's something a script author should be manipulating.

Here's what it looks like slackbot looks like:

```
  { id: 'USLACKBOT',
       name: 'slackbot',
       real_name: 'slackbot',
       email_address: '',
       slack: 
        { id: 'USLACKBOT',
          name: 'slackbot',
          deleted: false,
          status: null,
          color: '757575',
          real_name: 'slackbot',
          tz: null,
          tz_label: 'Pacific Daylight Time',
          tz_offset: -25200,
          profile: 
           { first_name: 'slackbot',
             last_name: '',
             image_24: 'https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_24.png',
             image_32: 'https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_32.png',
             image_48: 'https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_48.png',
             image_72: 'https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_72.png',
             image_192: 'https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_192.png',
             real_name: 'slackbot',
             real_name_normalized: 'slackbot',
             email: '' },
          is_admin: false,
          is_owner: false,
          is_primary_owner: false,
          is_restricted: false,
          is_ultra_restricted: false,
          is_bot: false,
          presence: 'active' } } },
```