### PR TITLE
robot.emit 'error' for slack client errors

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -46,10 +46,7 @@ class SlackBot extends Adapter
   error: (error) =>
     return @robot.logger.warning "Received rate limiting error #{JSON.stringify error}" if error.code == -1
 
-    @robot.logger.error "Received error #{JSON.stringify error}"
-    @robot.logger.error error.stack
-    @robot.logger.error "Exiting in 1 second"
-    setTimeout process.exit.bind(process, 1), 1000
+    @robot.emit 'error', error
 
   loggedIn: (self, team) =>
     @robot.logger.info "Logged in as #{self.name} of #{team.name}, but not yet connected"


### PR DESCRIPTION
I'm debugging an error I received overnight that crashed my hubot instance over at https://github.com/github/hubot-slack/pull/1 . Digging into it a bit more, I found that the adapter's error handler is exiting when the error happens.

This PR updates the adapter to not exit, and to use [hubot's error handling](https://hubot.github.com/docs/scripting/#error-handling) instead of logging it (the error handling logs by default).