### PR TITLE
Guard against real-time messaging API returning empty users

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -73,6 +73,7 @@ class SlackBot extends Adapter
       if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
+    return unless user?.id?
     newUser = {name: user.name, real_name: user.real_name, email_address: user.profile.email}
     if user.id of @robot.brain.data.users
       for key, value of @robot.brain.data.users[user.id]


### PR DESCRIPTION
I've been having problems with hubot crashing periodically, usually overnight when no one is activel. I found errors in the log like:

```
TypeError: Cannot read property 'email' of undefined
  at SlackBot.userChange (node_modules/hubot-slack/src/slack.coffee:79:7, <js>:113:36)
  at SlackBot.__bind [as userChange] (node_modules/hubot-slack/src/slack.coffee:1:1, <js>:3:61)
  at SlackBot.loggedIn (node_modules/hubot-slack/src/slack.coffee:64:7, <js>:83:28)
  at Client.__bind (node_modules/hubot-slack/src/slack.coffee:1:1, <js>:3:61)
  at Client.EventEmitter.emit (events.js:96:17)
  at Client._onLogin (node_modules/hubot-slack/node_modules/slack-client/src/client.js:100:14)
  at __bind (node_modules/hubot-slack/node_modules/slack-client/src/client.js:2:59)
  at IncomingMessage.Client._apiCall.req.on.callback.ok (node_modules/hubot-slack/node_modules/slack-client/src/client.js:670:22)
```

The line the error is coming from `user.profile.email`, which indicates the `user.profile` is undefined, so I first tried an existential operator, ie `user.profile?.email`. Crashes still happened, but with a different error:

```
[Thu Sep 24 2015 05:31:55 GMT-0700 (PDT)] ERROR TypeError: Cannot call method 'toString' of undefined
  at new User (/data/hubot/node_modules/hubot/src/user.coffee:9:19, <js>:14:47)
  at Brain.userForId (/data/hubot/node_modules/hubot/src/brain.coffee:106:7, <js>:93:16)
  at SlackBot.userChange (/data/hubot/node_modules/hubot-slack/src/slack.coffee:94:5, <js>:134:31)
  at SlackBot.__bind [as userChange] (/data/hubot/node_modules/hubot-slack/src/slack.coffee:1:1, <js>:3:61)
  at SlackBot.loggedIn (/data/hubot/node_modules/hubot-slack/src/slack.coffee:64:7, <js>:83:28)
  at Client.__bind (/data/hubot/node_modules/hubot-slack/src/slack.coffee:1:1, <js>:3:61)
  at Client.EventEmitter.emit (events.js:96:17)
  at Client._onLogin (/data/hubot/node_modules/hubot-slack/node_modules/slack-client/src/client.js:100:14)
  at __bind (/data/hubot/node_modules/hubot-slack/node_modules/slack-client/src/client.js:2:59)
  at IncomingMessage.Client._apiCall.req.on.callback.ok (/data/hubot/node_modules/hubot-slack/node_modules/slack-client/src/client.js:670:22)
  at IncomingMessage.EventEmitter.emit (events.js:123:20)
  at IncomingMessage._emitEnd (http.js:366:10)
  at HTTPParser.parserOnMessageComplete [as onMessageComplete] (http.js:149:23)
  at CleartextStream.socketOnData [as ondata] (http.js:1366:20)
  at CleartextStream.CryptoStream._push (tls.js:526:27)
  at SecurePair.cycle (tls.js:880:20)
  at EncryptedStream.CryptoStream.write (tls.js:267:13)
  at Socket.ondata (stream.js:38:26)
  at Socket.EventEmitter.emit (events.js:93:17)
  at TCP.onread (net.js:396:14)
```

I added some debug logging to see what user was coming in, and it was empty, ie `{}` rather than a full profile. This is coming directly from the real-time messaging API so I've reported this issue to Slack, but in the mean time checking for `user?.id?` should be sufficient to guard against it.