### PR TITLE
Update README to reflect Heroku changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,16 @@ This is a modified set of instructions based on the [instructions on the Hubot w
 
 - Install [heroku toolbelt](https://toolbelt.heroku.com/) if you haven't already.
 - `heroku create my-company-slackbot`
-- `heroku addons:add redistogo:nano`
+- `heroku addons:create redistogo:nano`
 - Activate the Hubot service on your ["Team Services"](http://my.slack.com/services/new/hubot) page inside Slack.
 - Add the [config variables](#adapter-configuration). For example:
 
         % heroku config:add HEROKU_URL=https://my-company-slackbot.herokuapp.com
         % heroku config:add HUBOT_SLACK_TOKEN=xoxb-1234-5678-91011-00e4dd
 
-- Deploy and start the bot:
+- Deploy the bot:
 
         % git push heroku master
-        % heroku ps:scale web=1
 
 - Profit!
 


### PR DESCRIPTION
- `heroku addons:add` has been deprecated and replaced with `heroku addons:create`
- Heroku will now automatically spin up a free dyno when you deploy so it's no longer necessary to launch one manually