### PR TITLE
Correctly @-mention users when using msg.reply

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -246,7 +246,7 @@ class SlackBot extends Adapter
 
     for msg in messages
       # TODO: Don't prefix username if replying in DM
-      @send envelope, "#{envelope.user.name}: #{msg}"
+      @send envelope, "<@#{envelope.user.id}>: #{msg}"
 
   topic: (envelope, strings...) ->
     channel = @client.getChannelGroupOrDMByName envelope.room


### PR DESCRIPTION
When using `msg.reply`, users would have to have their Slack nickname as a highlight word to receive notifications, because Hubot wasn't sending the special formatting to generate an @-reply. This fixes it so that Hubot generates correct @-replies.

Fixes #167.