### PR TITLE
Match slack usernames which have non alpha-numeric characters in them

### DIFF
--- a/test/slack.coffee
+++ b/test/slack.coffee
@@ -142,6 +142,42 @@ describe 'Send Messages', ->
     sentMessage = sentMessages.pop()
     sentMessage.should.equal 'foo <@U123>: bar'
 
+  it 'Should replace @obscure.name!@#$%^&*(): with <@U789> for mention (without colons)', ->
+    msg = 'foo @obscure.name!@#$%^&*(): bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <@U789> bar'
+
+  it 'Should replace @obscure.name!@#$%^&*():: with <@U789>: for mention (trailing colon)', ->
+    msg = 'foo @obscure.name!@#$%^&*():: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <@U789>: bar'
+
+  it 'Should replace @obscure.name!@#$%^&*():. with <@U789>. for mention (trailing full-stop)', ->
+    msg = 'foo @obscure.name!@#$%^&*():. bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <@U789>. bar'
+
+  it 'Should not replace @obscure.name!@#$%^&*():JUNK with <@789> for mention when there is a trailing word character', ->
+    msg = 'foo @obscure.name!@#$%^&*():JUNK bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo @obscure.name!@#$%^&*():JUNK bar'
+    
+  it 'Should handle junk all non word @mentions', ->
+    msg = 'foo @<><>: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo @<><>: bar'
+    
+  it 'Should replace @!@#$%: with <@999>: for mention (Punctuation only username)', ->
+    msg = 'foo @!@#$%: bar'
+    sentMessages = @slackbot.send {room: 'general'}, msg
+    sentMessage = sentMessages.pop()
+    sentMessage.should.equal 'foo <@U999>: bar'
+
   it 'Should replace @name with <@U123> for mention (first word)', ->
     msg = '@name: bar'
     sentMessages = @slackbot.send {room: 'general'}, msg

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -24,6 +24,16 @@ beforeEach ->
     id: 'U456'
     profile:
       email: 'self@example.com'
+  @stubs.obscureUser =
+    name: 'obscure.name!@#$%^&*():'
+    id: 'U789'
+    profile:
+      email: 'self@example.com'
+  @stubs.punctuationUser =
+    name: '!@#$%'
+    id: 'U999'
+    profile:
+      email: 'self@example.com'
   @stubs.team =
     name: 'Example Team'
   # Slack client
@@ -51,7 +61,7 @@ beforeEach ->
           @stubs._msg = if @stubs._msg then @stubs._msg + msg else msg
         }
       callback?()
-    users: [@stubs.user, @stubs.self]
+    users: [@stubs.user, @stubs.self, @stubs.obscureUser, @stubs.punctuationUser]
     dms: [
       {
         name: 'user2',


### PR DESCRIPTION
The change to allow the adapter to convert @mentions into proper `<@U123>` is excellent - however the matching isn't quite correct.

Currently it'll only match if the username is entirely alphanumeric, however slack usernames can contain any characters excluding whitespace. Within our slack team we have our usernames set as firstname.lastname - which doesn't work with the current implementation. I suspect that many professional slack teams use a similar username system.

Changing the implementation to match all non-whitespace characters doesn't work quite as expected either however, as a common use-case will be to mention usernames and suffix their usename with a colon, eg `@john.smith:`.

This change makes it match the entire word, eg `john.smith:` and look up the user. If it is a match, then we substitute. If no match is made and the trailing character is a non-word, we prune it and try again. We do this until we match a username, exhaust all characters or encounter a word character. This allows scripts to refer to any valid slack username and also append any trailing characters onto them such as colons, eg `@john.smith` or `@john.smith:`
