### PR TITLE
Handle reaction_added messages

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -38,6 +38,7 @@ class SlackBot extends Adapter
     @client.on 'open', @.open
     @client.on 'close', @.clientClose
     @client.on 'message', @.message
+    @client.on 'reaction_added', @.reactionAdded
     @client.on 'userChange', @.userChange
     @robot.brain.on 'loaded', @.brainLoaded
 
@@ -107,6 +108,7 @@ class SlackBot extends Adapter
       @client.removeListener 'open', @.open
       @client.removeListener 'close', @.clientClose
       @client.removeListener 'message', @.message
+      @client.removeListener 'reaction_added', @.reactionAdded
       @client.removeListener 'userChange', @.userChange
       process.exit 1
     else
@@ -170,6 +172,16 @@ class SlackBot extends Adapter
         text = "#{@robot.name} #{text}"
 
       @receive new SlackTextMessage user, text, rawText, msg
+
+  reactionAdded: (msg) =>
+    # Ignore our own reactions
+    return if msg.user == @self.id
+
+    channel = @client.getChannelGroupOrDMByID msg.item.channel
+    user = @robot.brain.userForId msg.user
+    user.room = channel.name
+    text = msg.reaction
+    @receive new SlackTextMessage user, text, text, msg
 
   removeFormatting: (text) ->
     # https://api.slack.com/docs/formatting

--- a/test/message.coffee
+++ b/test/message.coffee
@@ -40,6 +40,8 @@ describe 'Receiving a Slack message', ->
     msg = @stubs.robot.received[0]
     msg.should.be.an.instanceOf SlackTextMessage
     msg.text.should.equal "Hello world"
+    msg.user.id.should.equal @stubs.user.id
+    msg.user.room.should.equal @stubs.channel.name
 
   it 'should parse the text in the SlackTextMessage', ->
     @slackbot.message @makeMessage {
@@ -49,6 +51,8 @@ describe 'Receiving a Slack message', ->
     @stubs.robot.received.should.have.length 1
     msg = @stubs.robot.received[0]
     msg.should.be.an.instanceOf SlackTextMessage
+    msg.user.id.should.equal @stubs.user.id
+    msg.user.room.should.equal @stubs.channel.name
     msg.text.should.equal "Foo @name bar http://slack.com"
     msg.rawText.should.equal "Foo <@U123> bar <http://slack.com>"
 
@@ -132,6 +136,25 @@ describe 'Receiving a Slack message', ->
     @stubs.robot.received.should.have.length 1
     msg = @stubs.robot.received[0]
     msg.should.be.an.instanceOf SlackRawMessage
+
+  it 'should produce a SlackTextMessage for reaction_added events', ->
+    @slackbot.reactionAdded new ClientMessage {
+      type: 'reaction_added',
+      user: @stubs.user.id,
+      item: {
+        type: 'message',
+        channel: @stubs.channel.id,
+        ts: '1360782804.083113'
+      },
+      reaction: 'thumbsup',
+      event_ts: '1360782804.083113'
+    }
+    @stubs.robot.received.should.have.length 1
+    msg = @stubs.robot.received[0]
+    msg.should.be.an.instanceOf SlackTextMessage
+    msg.user.id.should.equal @stubs.user.id
+    msg.user.room.should.equal @stubs.channel.name
+    msg.rawMessage.reaction.should.equal 'thumbsup'
 
   describe 'should handle SlackRawMessage inheritance properly when Hubot', ->
     # this is a bit of a wacky one


### PR DESCRIPTION
Converts `reaction_added` messages to `SlackTextMessages` before passing them to Hubot. Used to implement behavior needed by 18F/hubot-slack-github-issues and depends on behavior from slackhq/node-slack-client#96. Also pertains to #251.

As I mentioned in the node-slack-client issue, I understand slack-client v2.0 is on its way soon, so no hard feelings if this gets closed without merging.

Squashed from PRs/commits:

  18F/node-slack-client#1:
    0b04a0b Handle reaction_added messages

  18F/node-slack-client#2:
    c65c172 Fix reaction_added message handling

  18F/node-slack-client#3:
    fd6fe4d Set user.room for reaction_added events
    129bbd6 Add clarifying comment to reactionAdded

cc: @afeld @ccostino