### PR TITLE
Slack-client upgrade to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/slackhq/hubot-slack/issues"
   },
   "dependencies": {
-    "slack-client": "~1.4.0"
+    "slack-client": "~1.4.1"
   },
   "devDependencies": {
     "coffee-script": "~1.7.1",


### PR DESCRIPTION
Slack-client 1.4.1 has some connectivity fixes compared to slack-client 1.4.0.