### PR TITLE
Support slack usernames with all allowed characters

### DIFF
--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -76,12 +76,12 @@ class SlackFormatter
     return if text is null # nothing to do
       
     if typeof text is 'string'
-      text.replace /(?:^| )@([\w]+)/gm, (match, username) =>
+      text.replace /(?:^| )@([\w\.-]+)/gm, (match, username) =>
         user = @dataStore.getUserByName(username)
         if user
-          match = match.replace /@[\w]+/, "<@#{user.id}>"
+          match = match.replace /@[\w\.-]+/, "<@#{user.id}>"
         else if username in MESSAGE_RESERVED_KEYWORDS
-          match = match.replace /@[\w]+/, "<!#{username}>"
+          match = match.replace /@[\w\.-]+/, "<!#{username}>"
         else
           match #do nothing if we don't revognize the name
 

--- a/test/formatter.coffee
+++ b/test/formatter.coffee
@@ -120,6 +120,14 @@ describe 'mentions()', ->
     foo = @formatter.mentions {text: 'Hello @name how are you?'}
     foo.text.should.equal 'Hello <@U123> how are you?'
 
+  it 'Should replace @name.lname with <@U124> (contains period)', ->
+    foo = @formatter.mentions {text: 'Hello @name.lname how are you?'}
+    foo.text.should.equal 'Hello <@U124> how are you?'
+
+  it 'Should replace @name-lname with <@U125> (contains hyphen)', ->
+    foo = @formatter.mentions {text: 'Hello @name-lname how are you?'}
+    foo.text.should.equal 'Hello <@U125> how are you?'
+
 
 
 describe 'outgoing()', ->

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -29,6 +29,16 @@ beforeEach ->
   @stubs.bot =
     name: 'testbot'
     id: 'B123'
+  @stubs.userperiod =
+    name: 'name.lname'
+    id: 'U124'
+    profile:
+      email: 'name.lname@example.com'
+  @stubs.userhyphen =
+    name: 'name-lname'
+    id: 'U125'
+    profile:
+      email: 'name-lname@example.com'
   @stubs.self =
     name: 'self'
     id: 'U456'
@@ -62,7 +72,7 @@ beforeEach ->
         return @stubs.channel if @stubs.channel.name == name
         for dm in @stubs.client.dataStore.dms
           return dm if dm.name is name
-      users: [@stubs.user, @stubs.self]
+      users: [@stubs.user, @stubs.self, @stubs.userperiod, @stubs.userhyphen]
       bots: [@stubs.bot]
       dms: [
         name: 'user2'


### PR DESCRIPTION
Prior to this change: a period or hyphen would cause this code to
only match the username before one of these unexpected characters.

This notifies the wrong person.

The logs would show:
DEBUG Sending to stackstorm: <@XXXXXXXXX>.welborn: host responded to ping.
Instead of:
DEBUG Sending to stackstorm: <@XXXXXXXXX>: host responded to ping.
When sending:
@john.welborn: host responded to ping.

Other special characters are not allowed.

From the slack ui when changing username:
"Usernames must be all lowercase. They cannot be longer than 21 characters and
can only contain letters, numbers, periods, hyphens, and underscores."