### PR TITLE
Handle bot message

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -113,11 +113,11 @@ class SlackBot extends Adapter
     subtype = subtype || 'message'
 
     # Hubot expects this format for TextMessage Listener
-    bot.room = channel.id if bot
-    user.room = channel.id if user
-    user = {
-      room: channel.id
-    } if !user && !bot
+    user = bot if bot
+    user = user if user
+    user = {} if !user && !bot
+    user.room = channel.id
+
 
     # Direct messages
     if channel.id[0] is 'D'
@@ -128,7 +128,7 @@ class SlackBot extends Adapter
     # Send to Hubot based on message type
     switch subtype
 
-      when 'message'
+      when 'message', 'bot_message'
         @robot.logger.debug "Received message: '#{text}' in channel: #{channel.name}, from: #{user.name}"
         @receive new TextMessage(user, text, message.ts)
 

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -131,3 +131,7 @@ describe 'Handling incoming messages', ->
   it 'Should handle unknown events as catchalls', ->
     @slackbot.message {subtype: 'hidey_ho', user: @stubs.user, channel: @stubs.channel}
     should.equal (@stubs._received instanceof CatchAllMessage), true
+
+  it 'Should not crash with bot messages', ->
+    @slackbot.message { subtype: 'bot_message', bot: @stubs.bot, channel: @stubs.channel, text: 'Pushing is the answer' }
+    should.equal (@stubs._received instanceof TextMessage), true

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -26,6 +26,9 @@ beforeEach ->
     id: 'U123'
     profile:
       email: 'email@example.com'
+  @stubs.bot =
+    name: 'testbot'
+    id: 'B123'
   @stubs.self =
     name: 'self'
     id: 'U456'
@@ -45,6 +48,9 @@ beforeEach ->
       getUserById: (id) =>
         for user in @stubs.client.dataStore.users
           return user if user.id is id
+      getBotById: (id) =>
+        for bot in @stubs.client.dataStore.bots
+          return bot if bot.id is id
       getUserByName: (name) =>
         for user in @stubs.client.dataStore.users
           return user if user.name is name
@@ -57,6 +63,7 @@ beforeEach ->
         for dm in @stubs.client.dataStore.dms
           return dm if dm.name is name
       users: [@stubs.user, @stubs.self]
+      bots: [@stubs.bot]
       dms: [
         name: 'user2'
         id: 'D5432'


### PR DESCRIPTION
#### PR Summary
Fixes a bug whereby messages with a bot user instead of a regular user hosed poor Hubot. Also, rolls message type `bot_message` in with `message`, as originally intended.

#### Related Issues
Fixes #323

#### Test strategy
Added tests around bot messages.