### PR TITLE
Default as user true

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -115,8 +115,9 @@ class SlackBot extends Adapter
   ###
   message: (message) =>
     {text, user, channel, subtype, topic, bot} = message
-    return if user && (user.id == @robot.adapter.self.id) #Ignore anything we sent
-    return if bot && (bot.id == @robot.adapter.self.bot_id) #Ignore anything we sent
+
+    return if user && (user.id == @self.id) #Ignore anything we sent
+    return if bot && (bot.id == @self.bot_id) #Ignore anything we sent
 
 
     subtype = subtype || 'message'

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -42,6 +42,12 @@ class SlackBot extends Adapter
   authenticated: (identity) =>
     {@self, team} = identity
 
+    # Find out bot_id
+    for user in identity.users
+      if user.id == @self.id
+        @self.bot_id = user.profile.bot_id
+        break
+
     # Provide our name to Hubot
     @robot.name = @self.name
 
@@ -109,6 +115,9 @@ class SlackBot extends Adapter
   ###
   message: (message) =>
     {text, user, channel, subtype, topic, bot} = message
+    return if user && (user.id == @robot.adapter.self.id) #Ignore anything we sent
+    return if bot && (bot.id == @robot.adapter.self.bot_id) #Ignore anything we sent
+
 
     subtype = subtype || 'message'
 

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -119,7 +119,6 @@ class SlackBot extends Adapter
     return if user && (user.id == @self.id) #Ignore anything we sent
     return if bot && (bot.id == @self.bot_id) #Ignore anything we sent
 
-
     subtype = subtype || 'message'
 
     # Hubot expects this format for TextMessage Listener

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -74,11 +74,11 @@ class SlackClient
     message = @format.outgoing(message)
 
     if typeof message isnt 'string'
-      @web.chat.postMessage(envelope.room, message.text, message)
+      @web.chat.postMessage(envelope.room, message.text, _.defaults(message, {'as_user': true}))
     else if /<.+\|.+>/.test(message)
-      @web.chat.postMessage(envelope.room, message)
+      @web.chat.postMessage(envelope.room, message, {'as_user' : true})
     else
-      @rtm.sendMessage(message, envelope.room)
+      @rtm.sendMessage(message, envelope.room) # RTM behaves as though `as_user` is true already
 
 
 module.exports = SlackClient

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -48,6 +48,16 @@ describe 'Send Messages', ->
     @slackbot.send {room: 'user2'}, msg
     @stubs._dmmsg.should.eql 'Test'
 
+
+describe 'Client sending message', ->
+  it 'Should append as_user = true', ->
+    @client.send {room: 'name'}, {text: 'foo', user: @stubs.user, channel: @stubs.channel}
+    @stubs._opts.as_user.should.eql true
+
+  it 'Should append as_user = true only as a default', ->
+    @client.send {room: 'name'}, {text: 'foo', user: @stubs.user, channel: @stubs.channel, as_user: false}
+    @stubs._opts.as_user.should.eql false
+
 describe 'Reply to Messages', ->
   it 'Should mention the user in a reply sent in a channel', ->
     sentMessages = @slackbot.reply {user: @stubs.user, room: @stubs.channel.id}, 'message'

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -141,5 +141,5 @@ describe 'Handling incoming messages', ->
     should.equal @stubs._received, undefined
 
   it 'Should ignore messages it sent itself, if sent as a botuser', ->
-    @slackbot.message { subtype: 'bot_message', user: @stubs.self_bot, channel: @stubs.channel, text: 'Ignore me' }
+    @slackbot.message { subtype: 'bot_message', bot: @stubs.self_bot, channel: @stubs.channel, text: 'Ignore me' }
     should.equal @stubs._received, undefined

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -135,3 +135,11 @@ describe 'Handling incoming messages', ->
   it 'Should not crash with bot messages', ->
     @slackbot.message { subtype: 'bot_message', bot: @stubs.bot, channel: @stubs.channel, text: 'Pushing is the answer' }
     should.equal (@stubs._received instanceof TextMessage), true
+
+  it 'Should ignore messages it sent itself', ->
+    @slackbot.message { subtype: 'bot_message', user: @stubs.self, channel: @stubs.channel, text: 'Ignore me' }
+    should.equal @stubs._received, undefined
+
+  it 'Should ignore messages it sent itself, if sent as a botuser', ->
+    @slackbot.message { subtype: 'bot_message', user: @stubs.self_bot, channel: @stubs.channel, text: 'Ignore me' }
+    should.equal @stubs._received, undefined

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -45,6 +45,11 @@ beforeEach ->
     bot_id: 'B456'
     profile:
       email: 'self@example.com'
+  @stubs.self_bot =
+    name: 'self'
+    id: 'B456'
+    profile:
+      email: 'self@example.com'
   @stubs.team =
     name: 'Example Team'
   # Slack client

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -99,6 +99,7 @@ beforeEach ->
   @stubs.chatMock =
     postMessage: (room, messageText, message) =>
       @stubs._msg = messageText
+      @stubs._opts = message
       @stubs._room = room
   @stubs.channelsMock =
     setTopic: (id, topic) =>

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -42,6 +42,7 @@ beforeEach ->
   @stubs.self =
     name: 'self'
     id: 'U456'
+    bot_id: 'B456'
     profile:
       email: 'self@example.com'
   @stubs.team =
@@ -134,6 +135,7 @@ beforeEach ->
   _.merge @slackbot.client.web.chat, @stubs.chatMock
   _.merge @slackbot.client.web.channels, @stubs.channelsMock
   _.merge @slackbot, @stubs.receiveMock
+  @slackbot.self = @stubs.self
 
   @formatter = new SlackFormatter @stubs.client.dataStore
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> Default all messages to `as_user = true`. Also ignore all messages we send.

#### Related Issues
> Fixes #336

#### Test strategy
> Wrote tests to ensure that as_user is being set to a default value, and that that default value can be overridden.


In the course of writing this, I realized that bots do not ignore messages they themselves sent. This becomes apparent with the new functionality especially, so I've rolled logic for that (and tests!) into this PR as well.