### PR TITLE
Encode entities in outgoing hubot messages to prevent Slack from trying to parse them.

### DIFF
--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -75,11 +75,11 @@ class SlackFormatter
   mentions: (text) ->
     return if text is null # nothing to do
 
-    text = text.replace /&/g, '&amp;'
-    text = text.replace /</g, '&lt;'
-    text = text.replace />/g, '&gt;'
-
     if typeof text is 'string'
+      text = text.replace /&/g, '&amp;'
+      text = text.replace /</g, '&lt;'
+      text = text.replace />/g, '&gt;'
+
       text.replace /(?:^| )@([\w\.-]+)/gm, (match, username) =>
         user = @dataStore.getUserByName(username)
         if user

--- a/src/formatter.coffee
+++ b/src/formatter.coffee
@@ -74,7 +74,11 @@ class SlackFormatter
   ###
   mentions: (text) ->
     return if text is null # nothing to do
-      
+
+    text = text.replace /&/g, '&amp;'
+    text = text.replace /</g, '&lt;'
+    text = text.replace />/g, '&gt;'
+
     if typeof text is 'string'
       text.replace /(?:^| )@([\w\.-]+)/gm, (match, username) =>
         user = @dataStore.getUserByName(username)

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -74,5 +74,5 @@ describe 'send()', ->
 
   it 'Should send an object message to room', ->
     @client.send {room: 'room3'}, '<test|test>'
-    @stubs._msg.should.equal '<test|test>'
+    @stubs._msg.should.equal '&lt;test|test&gt;'
     @stubs._room.should.equal 'room3'

--- a/test/formatter.coffee
+++ b/test/formatter.coffee
@@ -133,6 +133,10 @@ describe 'mentions()', ->
     foo = @formatter.mentions {text: 'Hello @name-lname how are you?'}
     foo.text.should.equal 'Hello <@U125> how are you?'
 
+  it 'Should encode entities', ->
+    foo = @formatter.mentions {text: 'Hello <foo|bar> &'}
+    foo.text.should.equal "Hello &lt;foo|bar&gt; &amp;"
+
 describe 'outgoing()', ->
   it 'Should just pass things to mentions', ->
     foo = @formatter.mentions {text: 'Hello @name how are you?'}


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> Encode entities in outgoing messages to prevent Slack errors when handling the message.

#### Related Issues
> Fixes #344 

#### Test strategy
> Added tests to verify encoding. Manually tested with Hubot
Signed-off-by: Kyle Reed <kallanreed@outlook.com>