### PR TITLE
Accept room names for robot.messageRoom

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -73,7 +73,7 @@ class SlackClient
   send: (envelope, message) ->
     message = @format.outgoing(message)
     room = envelope.room
-    if !(room.match /C0[A-Z0-9]{7}/)
+    if !(room.match /[A-Z]/) # slack rooms are always lowercase
       # try to translate room name to room id
       channelForName = @rtm.dataStore.getChannelByName(room)
       if channelForName

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -7,13 +7,13 @@ SLACK_CLIENT_OPTIONS =
 
 
 class SlackClient
-  
+
   constructor: (options) ->
     _.merge SLACK_CLIENT_OPTIONS, options
 
     # RTM is the default communication client
     @rtm = new RtmClient options.token, options
-    
+
     # Web is the fallback for complex messages
     @web = new WebClient options.token, options
 
@@ -36,7 +36,7 @@ class SlackClient
   ###
   on: (name, callback) ->
     @listeners.push(name)
-    
+
     # override message to format text
     if name is "message"
       @rtm.on name, (message) =>
@@ -72,13 +72,19 @@ class SlackClient
   ###
   send: (envelope, message) ->
     message = @format.outgoing(message)
+    room = envelope.room
+    if !(room.match /C0[A-Z0-9]{7}/)
+      # try to translate room name to room id
+      channelForName = @rtm.dataStore.getChannelByName(room)
+      if channelForName
+        room = channelForName.id
 
     if typeof message isnt 'string'
-      @web.chat.postMessage(envelope.room, message.text, _.defaults(message, {'as_user': true}))
+      @web.chat.postMessage(room, message.text, _.defaults(message, {'as_user': true}))
     else if /<.+\|.+>/.test(message)
-      @web.chat.postMessage(envelope.room, message, {'as_user' : true})
+      @web.chat.postMessage(room, message, {'as_user' : true})
     else
-      @rtm.sendMessage(message, envelope.room) # RTM behaves as though `as_user` is true already
+      @rtm.sendMessage(message, room) # RTM behaves as though `as_user` is true already
 
 
 module.exports = SlackClient

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -65,17 +65,22 @@ describe 'send()', ->
   it 'Should send a plain string message to room', ->
     @client.send {room: 'room1'}, 'Message'
     @stubs._msg.should.equal 'Message'
-    @stubs._room.should.equal 'C00000001'
+    @stubs._room.should.equal 'room1'
 
   it 'Should send an object message to room', ->
     @client.send {room: 'room2'}, {text: 'textMessage'}
     @stubs._msg.should.equal 'textMessage'
-    @stubs._room.should.equal 'C00000002'
+    @stubs._room.should.equal 'room2'
 
   it 'Should send an object message to room', ->
     @client.send {room: 'room3'}, '<test|test>'
     @stubs._msg.should.equal '<test|test>'
-    @stubs._room.should.equal 'C00000003'
+    @stubs._room.should.equal 'room3'
+
+  it 'Should translate known room names to a channel id', ->
+    @client.send {room: 'known_room'}, 'Message'
+    @stubs._msg.should.equal 'Message'
+    @stubs._room.should.equal 'C00000004'
 
   it 'Should not translate an unknown room', ->
     @client.send {room: 'unknown_room'}, 'Message'

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -65,14 +65,19 @@ describe 'send()', ->
   it 'Should send a plain string message to room', ->
     @client.send {room: 'room1'}, 'Message'
     @stubs._msg.should.equal 'Message'
-    @stubs._room.should.equal 'room1'
+    @stubs._room.should.equal 'C00000001'
 
   it 'Should send an object message to room', ->
     @client.send {room: 'room2'}, {text: 'textMessage'}
     @stubs._msg.should.equal 'textMessage'
-    @stubs._room.should.equal 'room2'
+    @stubs._room.should.equal 'C00000002'
 
   it 'Should send an object message to room', ->
     @client.send {room: 'room3'}, '<test|test>'
     @stubs._msg.should.equal '<test|test>'
-    @stubs._room.should.equal 'room3'
+    @stubs._room.should.equal 'C00000003'
+
+  it 'Should not translate an unknown room', ->
+    @client.send {room: 'unknown_room'}, 'Message'
+    @stubs._msg.should.equal 'Message'
+    @stubs._room.should.equal 'unknown_room'

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -99,9 +99,7 @@ beforeEach ->
     dataStore:
       getChannelByName: (name) =>
         switch name
-          when 'room1' then {id: 'C00000001'}
-          when 'room2' then {id: 'C00000002'}
-          when 'room3' then {id: 'C00000003'}
+          when 'known_room' then {id: 'C00000004'}
           else undefined
   @stubs.chatMock =
     postMessage: (room, messageText, message) =>

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -96,6 +96,13 @@ beforeEach ->
     sendMessage: (message, room) =>
       @stubs._msg = message
       @stubs._room = room
+    dataStore:
+      getChannelByName: (name) =>
+        switch name
+          when 'room1' then {id: 'C00000001'}
+          when 'room2' then {id: 'C00000002'}
+          when 'room3' then {id: 'C00000003'}
+          else undefined
   @stubs.chatMock =
     postMessage: (room, messageText, message) =>
       @stubs._msg = messageText


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Previous to hubot-slack 4.0.0, `robot.messageRoom` would accept room names.  This PR translates room names to room ids, in order to improve compatibility with existing hubot scripts.

#### Test strategy
Write a hubot script that sends a message to a room by name, e.g.:
```coffeescript
module.exports = (robot) ->

  robot.respond /test messageRoom/, (msg) ->
    room = 'general'
    robot.messageRoom room, 'hi there!'
```
This will not work with hubot-slack 4.0.2.