### PR TITLE
Adding back channel lookup for non-slack plugins

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -86,6 +86,12 @@ class SlackClient
     @robot.logger.debug "~~~~~~~"
     @robot.logger.debug message
     {room} = envelope
+    
+    if !(room.match /[A-Z]/) # slack rooms are always lowercase
+      # try to translate room name to room id
+      channelForName = @rtm.dataStore.getChannelByName(room)
+      room = channelForName.id if channelForName
+    
     options = { as_user: true, link_names: 1 }
 
     if typeof message isnt 'string'


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
This was brought to my attention offline
> Without this change, any plugin written for hubot would be *required* to be aware of slack, as it would be *required* to look up the channel ID in any circumstances except replying to a message.

> This means that most "generic" plugins (for example, hubot-notify) would have to be re-written to be specific to slack - something that goes against the freedoms of having these plugins etc within hubot.


#### Related Issues
N/A

#### Test strategy
Existing tests
