### PR TITLE
Fixes #332 by allowing user objects to be envelopes

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -83,7 +83,6 @@ class SlackBot extends Adapter
     sent_messages = []
     for message in messages
       if message isnt ''
-        @robot.logger.debug "Sending to #{envelope.room}: #{message}"
         sent_messages.push @client.send(envelope, message)
     return sent_messages
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -83,15 +83,15 @@ class SlackClient
   Send a message to Slack using the best client for the message type
   ###
   send: (envelope, message) ->
-    @robot.logger.debug "~~~~~~~"
-    @robot.logger.debug message
-    {room} = envelope
-    
-    if !(room.match /[A-Z]/) # slack rooms are always lowercase
-      # try to translate room name to room id
-      channelForName = @rtm.dataStore.getChannelByName(room)
-      room = channelForName.id if channelForName
-    
+    if envelope.room
+      room = envelope.room
+    else if envelope.name #in case we were sent a user object _as_ the envelope
+      room = "@"+envelope.name
+    else if envelope.id #in case we only have a user name in the user object sent to us
+      room = envelope.id
+
+    @robot.logger.debug "Sending to #{room}: #{message}"
+
     options = { as_user: true, link_names: 1 }
 
     if typeof message isnt 'string'

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -94,12 +94,8 @@ class SlackClient
 
     if typeof message isnt 'string'
       @web.chat.postMessage(room, message.text, _.defaults(message, options))
-    else if /<.+\|.+|>|@|#/.test(message)
-      @robot.logger.debug "sending with options"
-      @robot.logger.debug options
-      @web.chat.postMessage(room, message, options)
     else
-      @rtm.sendMessage(message, room)
+      @web.chat.postMessage(room, message, options)
 
 
 module.exports = SlackClient

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -85,9 +85,7 @@ class SlackClient
   send: (envelope, message) ->
     if envelope.room
       room = envelope.room
-    else if envelope.name #in case we were sent a user object _as_ the envelope
-      room = "@"+envelope.name
-    else if envelope.id #in case we only have a user name in the user object sent to us
+    else if envelope.id #Maybe we were sent a user object or channel object. Use the id, in that case.
       room = envelope.id
 
     @robot.logger.debug "Sending to #{room}: #{message}"

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -52,7 +52,7 @@ describe 'Send Messages', ->
   it 'Should send a message to a user', ->
     @slackbot.send @stubs.user, 'message'
     @stubs._dmmsg.should.eql 'message'
-    @stubs._room.should.eql "@"+@stubs.user.name
+    @stubs._room.should.eql @stubs.user.id
 
 
 describe 'Client sending message', ->

--- a/test/bot.coffee
+++ b/test/bot.coffee
@@ -41,12 +41,18 @@ describe 'Send Messages', ->
   it 'Should open a DM channel if needed', ->
     msg = 'Test'
     @slackbot.send {room: 'name'}, msg
-    @stubs._msg.should.eql 'Test'
+    @stubs._msg.should.eql msg
 
   it 'Should use an existing DM channel if possible', ->
     msg = 'Test'
-    @slackbot.send {room: 'user2'}, msg
-    @stubs._dmmsg.should.eql 'Test'
+    @slackbot.send {room: '@user2'}, msg
+    @stubs._dmmsg.should.eql msg
+    @stubs._room.should.eql '@user2'
+
+  it 'Should send a message to a user', ->
+    @slackbot.send @stubs.user, 'message'
+    @stubs._dmmsg.should.eql 'message'
+    @stubs._room.should.eql "@"+@stubs.user.name
 
 
 describe 'Client sending message', ->

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -101,4 +101,4 @@ describe 'send()', ->
   it 'Should be able to send a DM to a user object', ->
     @client.send @stubs.user, 'DM Message'
     @stubs._dmmsg.should.equal 'DM Message'
-    @stubs._room.should.equal "@"+@stubs.user.name
+    @stubs._room.should.equal @stubs.user.id

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -87,3 +87,18 @@ describe 'send()', ->
     @client.send {room: 'unknown_room'}, 'Message'
     @stubs._msg.should.equal 'Message'
     @stubs._room.should.equal 'unknown_room'
+
+  it 'Should be able to send a DM to a user by id', ->
+    @client.send {room: @stubs.user.id}, 'DM Message'
+    @stubs._dmmsg.should.equal 'DM Message'
+    @stubs._room.should.equal @stubs.user.id
+
+  it 'Should be able to send a DM to a user by username', ->
+    @client.send {room: "@"+@stubs.user.name}, 'DM Message'
+    @stubs._dmmsg.should.equal 'DM Message'
+    @stubs._room.should.equal "@"+@stubs.user.name
+
+  it 'Should be able to send a DM to a user object', ->
+    @client.send @stubs.user, 'DM Message'
+    @stubs._dmmsg.should.equal 'DM Message'
+    @stubs._room.should.equal "@"+@stubs.user.name

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -77,11 +77,11 @@ describe 'send()', ->
     @stubs._msg.should.equal '<test|test>'
     @stubs._room.should.equal 'room3'
 
-  #### Handled by Slack API now
-  # it 'Should translate known room names to a channel id', ->
-  #   @client.send {room: 'known_room'}, 'Message'
-  #   @stubs._msg.should.equal 'Message'
-  #   @stubs._room.should.equal 'C00000004'
+  # This case and the following are cool. You can post a message to a channel as a name
+  it 'Should not translate known room names to a channel id', ->
+    @client.send {room: 'known_room'}, 'Message'
+    @stubs._msg.should.equal 'Message'
+    @stubs._room.should.equal 'known_room'
 
   it 'Should not translate an unknown room', ->
     @client.send {room: 'unknown_room'}, 'Message'

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -13,6 +13,16 @@ _ = require 'lodash'
 # Stubs are recreated before each test.
 beforeEach ->
   @stubs = {}
+
+  @stubs.send = (room, msg, opts) =>
+    @stubs._room = room
+    @stubs._opts = opts
+    if /^[UD@][\d\w]+/.test(room)
+      @stubs._dmmsg = msg
+    else
+      @stubs._msg = msg
+    msg
+
   @stubs.channel =
     name: 'general'
     id: 'C123'
@@ -61,11 +71,6 @@ beforeEach ->
     name: 'Example Team'
   # Slack client
   @stubs.client =
-    send: (env, msg) =>
-      if /user/.test(env.room)
-        @stubs._dmmsg = msg
-      else
-      @stubs._msg = msg
 
     dataStore:
       getUserById: (id) =>
@@ -100,9 +105,8 @@ beforeEach ->
       console.log(callback)
       callback(name)
     removeListener: (name) =>
-    sendMessage: (message, room) =>
-      @stubs._msg = message
-      @stubs._room = room
+    sendMessage: (msg, room) =>
+      @stubs.send room, msg
     dataStore:
       getChannelByName: (name) =>
         switch name
@@ -113,10 +117,8 @@ beforeEach ->
           when @stubs.channel.id then @stubs.channel
           when @stubs.DM.id then @stubs.DM
   @stubs.chatMock =
-    postMessage: (room, messageText, options) =>
-      @stubs._msg = messageText
-      @stubs._opts = options
-      @stubs._room = room
+    postMessage: (msg, room, opts) =>
+      @stubs.send(msg, room, opts)
   @stubs.channelsMock =
     setTopic: (id, topic) =>
       @stubs._topic = topic


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> Now you can pass in user objects as message envelopes.

#### Related Issues
> Fixes #332

#### Test strategy
> Added tests around passing in user names (prepended with "@") and user objects
