### PR TITLE
Add hubot.Robot.react

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^3.10.1"
   },
   "devDependencies": {
-    "hubot": "~2.11",
+    "hubot": "^2.19",
     "coffee-coverage": "^1.0.1",
     "coffee-script": "~1.7.1",
     "coveralls": "^2.11.9",

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -1,7 +1,34 @@
-{Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage, Message, CatchAllMessage} = require.main.require 'hubot'
+{Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage, Message, CatchAllMessage, Robot} = require.main.require 'hubot'
 
 SlackClient = require './client'
 ReactionMessage = require './reaction-message'
+
+# Public: Adds a Listener for ReactionMessages with the provided matcher,
+# options, and callback
+#
+# matcher  - A Function that determines whether to call the callback.
+#            Expected to return a truthy value if the callback should be
+#            executed (optional).
+# options  - An Object of additional parameters keyed on extension name
+#            (optional).
+# callback - A Function that is called with a Response object if the
+#            matcher function returns true.
+#
+# Returns nothing.
+Robot::react = (matcher, options, callback) ->
+  matchReaction = (msg) -> msg instanceof ReactionMessage
+
+  if arguments.length == 1
+    return @listen matchReaction, matcher
+
+  else if matcher instanceof Function
+    matchReaction = (msg) -> msg instanceof ReactionMessage && matcher(msg)
+
+  else
+    callback = options
+    options = matcher
+
+  @listen matchReaction, options, callback
 
 class SlackBot extends Adapter
 

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -5,7 +5,7 @@ SlackFormatter = require '../src/formatter'
 SlackClient = require '../src/client'
 {EventEmitter} = require 'events'
 # Use Hubot's brain in our stubs
-{Brain} = require 'hubot'
+{Brain, Robot} = require 'hubot'
 _ = require 'lodash'
 
 # Stub a few interfaces to grease the skids for tests. These are intentionally
@@ -151,6 +151,9 @@ beforeEach ->
     # attach a real Brain to the robot
     robot.brain = new Brain robot
     robot.name = 'bot'
+    robot.listeners = []
+    robot.listen = Robot.prototype.listen.bind(robot)
+    robot.react = Robot.prototype.react.bind(robot)
     robot
   @stubs.callback = do ->
     return "done"


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Add hubot.Robot.react

Per #360, this implements `robot.react` as a replacement for the approach from [mbland/hubot-slack-reaction-example v1.1.0](https://github.com/mbland/hubot-slack-reaction-example/blob/v1.1.0/scripts/handle-reaction.coffee). Specifically, the `ReactionMessage` definition will no longer be required in client code, and this:

```coffeescript
robot.listen(
  (message) -> message instanceof ReactionMessage
  handleReaction
)
```
can now become:

```coffeescript
robot.react handleReaction
```

`Robot.react` can also take optional  `matcher` and `options` arguments just like the underlying `Robot.listen` method:

```coffeescript
robot.react(
  (message) -> message.type == 'added' && message.reaction == '+1'
  {id: 'my-reaction-matcher'}
  handleReaction
)
```

__NOTE:__ It was necessary to bump the `hubot` development dependency to at least v2.16.0, since that is when the `Robot.listen` method first appeared. I took the liberty of bumping it to the current version by specifying `^2.19`.

#### Related Issues
Follows from the post-merge discussion of #360.

#### Test strategy
Unit tests to validate the new `Robot.react` method as part of the existing `Adapter` and the new `Robot.react` suites.

cc: @johnagan @DEGoodmanWilson